### PR TITLE
feat: add max-preempt filtering for partial rollout

### DIFF
--- a/blackbox_server/adapters/openclaw.py
+++ b/blackbox_server/adapters/openclaw.py
@@ -221,6 +221,7 @@ class OpenClawAdapter(BackendAdapter):
                     timeout=self._remaining_timeout(deadline, operation="wait for rollout proxy drain")
                 )
                 await self._raise_if_proxy_context_overflow()
+                await self._raise_if_proxy_rollout_invalidated()
 
             _raise_if_openclaw_max_steps_exceeded(raw, self._options)
 
@@ -871,6 +872,16 @@ class OpenClawAdapter(BackendAdapter):
         typed_error = backend_context_overflow_from_proxy_payload(payload)
         if typed_error is not None:
             raise typed_error
+
+    async def _raise_if_proxy_rollout_invalidated(self) -> None:
+        if self._proxy is None:
+            return
+        payload = await self._proxy.consume_rollout_invalidated_error()
+        if payload is None:
+            return
+        error = payload.get("error") or "rollout_invalidated"
+        message = payload.get("message") or "Dressage rollout was invalidated."
+        raise BackendTransportError(f"Dressage proxy {error}: {message}")
 
 
 def _maybe_int(value: Any) -> int | None:

--- a/blackbox_server/proxy/rollout_llm_proxy.py
+++ b/blackbox_server/proxy/rollout_llm_proxy.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__)
 
 DRESSAGE_ROLLOUT_INVALIDATED_ERRORS = {
     "generation_preempted",
+    "partial_rollout_staleness_exceeded",
     "trajectory_version_changed",
 }
 

--- a/dressage/paddock/blackbox/failures.py
+++ b/dressage/paddock/blackbox/failures.py
@@ -163,16 +163,42 @@ def record_blackbox_abort_for_retry(
         history = []
         metadata["blackbox_failure_history"] = history
 
+    http_error_metadata = _http_status_error_metadata(exc)
     error_text = str(exc)
-    history.append(
-        {
-            "session_id": session_id,
-            "error_type": type(exc).__name__,
-            "error": error_text,
-            "retry_count": metadata.get("dressage_retry_count", 0),
-        }
-    )
+    if http_error_metadata.get("http_response_body"):
+        error_text = f"{error_text}; response_body={http_error_metadata['http_response_body']}"
+
+    history_entry = {
+        "session_id": session_id,
+        "error_type": type(exc).__name__,
+        "error": error_text,
+        "retry_count": metadata.get("dressage_retry_count", 0),
+    }
+    history_entry.update(http_error_metadata)
+    history.append(history_entry)
     metadata["blackbox_error"] = error_text
+    for key, value in http_error_metadata.items():
+        metadata[f"blackbox_{key}"] = value
+
+
+def _http_status_error_metadata(exc: BaseException) -> dict[str, Any]:
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return {}
+
+    response = exc.response
+    payload: dict[str, Any] = {
+        "http_status_code": response.status_code,
+    }
+    body = response.text
+    if body:
+        text, truncated = _truncated_metadata_text(body)
+        payload["http_response_body"] = text
+        payload["http_response_body_truncated"] = truncated
+    try:
+        payload["http_response_json"] = _json_safe(response.json())
+    except ValueError:
+        pass
+    return payload
 
 
 def _agent_payload_state(payload: Any) -> str | None:

--- a/dressage/proxy/generation_controller.py
+++ b/dressage/proxy/generation_controller.py
@@ -339,6 +339,12 @@ class GenerationController:
                 active.state = "quiesced"
                 active.quiesced_event.set()
 
+            if preempted:
+                if not self._partial_rollout:
+                    raise GenerationPreempted(
+                        "SGLang generation was interrupted while partial rollout resume is disabled"
+                    )
+
             if (
                 context_window is not None
                 and len(input_ids) + len(generated_ids) > context_window
@@ -359,10 +365,6 @@ class GenerationController:
 
             if not preempted:
                 break
-            if not self._partial_rollout:
-                raise GenerationPreempted(
-                    "SGLang generation was interrupted while partial rollout resume is disabled"
-                )
 
             self._suspended_generations += 1
             try:

--- a/dressage/proxy/server.py
+++ b/dressage/proxy/server.py
@@ -68,6 +68,16 @@ def _positive_int(value: str) -> int:
     return parsed
 
 
+def _non_negative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be greater than or equal to 0")
+    return parsed
+
+
 def _real_token_version(value: Any) -> str | None:
     if value is None:
         return None
@@ -88,6 +98,71 @@ def _session_real_versions(session: Session) -> set[str]:
             if version is not None:
                 versions.add(version)
     return versions
+
+
+def _ordered_real_versions(values: list[Any]) -> list[str]:
+    versions: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        version = _real_token_version(value)
+        if version is None or version in seen:
+            continue
+        versions.append(version)
+        seen.add(version)
+    return versions
+
+
+def _session_response_versions(session: Session) -> list[Any]:
+    values: list[Any] = []
+    for step in session.steps:
+        values.extend(step.response_versions)
+    return values
+
+
+def _raise_if_partial_version_span_exceeded(
+    *,
+    session: Session,
+    candidate_versions: list[Any],
+    partial_rollout: bool,
+    max_partial_rollout_preempts: int | None,
+) -> None:
+    if not partial_rollout or max_partial_rollout_preempts is None:
+        return
+    versions = _ordered_real_versions(
+        [*_session_response_versions(session), *candidate_versions]
+    )
+    version_span = len(versions)
+    version_switches = max(0, version_span - 1)
+    if version_switches <= max_partial_rollout_preempts:
+        return
+    logger.warning(
+        "reject partial rollout: error=partial_rollout_staleness_exceeded "
+        "session_id=%s instance_id=%s version_span=%s version_switches=%s "
+        "max_preempts=%s versions=%s",
+        session.session_id,
+        session.instance_id,
+        version_span,
+        version_switches,
+        max_partial_rollout_preempts,
+        versions,
+    )
+    raise HTTPException(
+        status_code=502,
+        detail={
+            "error": "partial_rollout_staleness_exceeded",
+            "message": (
+                "Partial rollout model version span exceeded limit; "
+                "rejecting the trajectory instead of continuing it."
+            ),
+            "versions": versions,
+            "version_span": version_span,
+            "version_switches": version_switches,
+            "max_preempts": max_partial_rollout_preempts,
+            "max_version_span": max_partial_rollout_preempts + 1,
+            "session_id": session.session_id,
+            "instance_id": session.instance_id,
+        },
+    )
 
 
 def _raise_if_cross_version_trajectory(
@@ -405,11 +480,14 @@ def create_app(
     dynamic_max_tokens: bool = True,
     use_rollout_routing_replay: bool = False,
     partial_rollout: bool = False,
+    max_partial_rollout_preempts: int | None = None,
 ) -> FastAPI:
     """Create the Dressage proxy FastAPI app."""
 
     if context_window is not None and context_window <= 0:
         raise ValueError("context_window must be greater than 0 when provided")
+    if max_partial_rollout_preempts is not None and max_partial_rollout_preempts < 0:
+        raise ValueError("max_partial_rollout_preempts must be greater than or equal to 0")
     if trajectory_build_mode not in {"last_step", "concat"}:
         raise ValueError(
             "trajectory_build_mode must be 'last_step' or 'concat', "
@@ -1271,6 +1349,13 @@ def create_app(
                 candidate_versions=[*response_versions, response_version, request_version],
                 partial_rollout=partial_rollout,
             )
+            if not output_overflow:
+                _raise_if_partial_version_span_exceeded(
+                    session=session,
+                    candidate_versions=response_versions,
+                    partial_rollout=partial_rollout,
+                    max_partial_rollout_preempts=max_partial_rollout_preempts,
+                )
             if session.rollout_epoch is None:
                 session.rollout_epoch = router_response.rollout_epoch
             prompt_versions = [_INPUT_TOKEN_VERSION] * len(input_ids)
@@ -1591,6 +1676,7 @@ def create_app(
                 "dynamic_max_tokens": dynamic_max_tokens,
                 "use_rollout_routing_replay": use_rollout_routing_replay,
                 "partial_rollout": partial_rollout,
+                "max_partial_rollout_preempts": max_partial_rollout_preempts,
             },
         }
 
@@ -1687,6 +1773,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Allow interrupted SGLang generations to resume from partial output.",
     )
+    parser.add_argument(
+        "--max-partial-rollout-preempts",
+        type=_non_negative_int,
+        default=None,
+        help="Maximum model weight version switches allowed for one partial-rollout session.",
+    )
     return parser.parse_args()
 
 
@@ -1718,6 +1810,7 @@ def main() -> None:
         dynamic_max_tokens=args.dynamic_max_tokens,
         use_rollout_routing_replay=args.use_rollout_routing_replay,
         partial_rollout=args.dressage_partial_rollout,
+        max_partial_rollout_preempts=args.max_partial_rollout_preempts,
     )
     uvicorn.run(app, host=args.host, port=args.port)
 

--- a/dressage/rollout/fully_async_rollout.py
+++ b/dressage/rollout/fully_async_rollout.py
@@ -19,6 +19,8 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_STALENESS_ERROR_MARKER = "partial_rollout_staleness_exceeded"
+
 try:
     from slime.rollout.base_types import RolloutFnTrainOutput
     from slime.rollout.sglang_rollout import GenerateState, generate_and_rm_group
@@ -108,9 +110,31 @@ def _short_error(value: Any, limit: int = 500) -> str:
     return f"{text[:limit]}..."
 
 
+def _contains_staleness_marker(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, dict):
+        return any(
+            _contains_staleness_marker(key) or _contains_staleness_marker(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple, set)):
+        return any(_contains_staleness_marker(item) for item in value)
+    return _STALENESS_ERROR_MARKER in str(value)
+
+
 def _sample_metadata(sample: Any) -> dict[str, Any]:
     metadata = getattr(sample, "metadata", None)
     return metadata if isinstance(metadata, dict) else {}
+
+
+def _group_has_staleness_failure(
+    group: list[Any],
+    error: BaseException | None = None,
+) -> bool:
+    if _contains_staleness_marker(error):
+        return True
+    return any(_contains_staleness_marker(_sample_metadata(sample)) for sample in group)
 
 
 def _group_failure_summary(

--- a/dressage/rollout/log_rollout.py
+++ b/dressage/rollout/log_rollout.py
@@ -16,6 +16,21 @@ from typing import Any
 
 from dressage.training.log_helpers import compute_trajectory_mean_raw_reward
 
+_STALENESS_WANDB_METRICS_DEFINED = False
+
+
+def _define_staleness_wandb_metrics(args: Any) -> None:
+    global _STALENESS_WANDB_METRICS_DEFINED
+    if _STALENESS_WANDB_METRICS_DEFINED or not getattr(args, "use_wandb", False):
+        return
+
+    import wandb
+
+    if wandb.run is None:
+        return
+    wandb.define_metric("staleness/*", step_metric="rollout/step")
+    _STALENESS_WANDB_METRICS_DEFINED = True
+
 
 def _sample_has_trainable_loss(sample: Any) -> bool:
     if getattr(sample, "remove_sample", False):
@@ -51,6 +66,8 @@ def log_rollout_data(
     metric rides through ``log_dict = {**(rollout_extra_metrics or {})}``
     in slime's ``_log_rollout_data``.
     """
+    _define_staleness_wandb_metrics(args)
+
     parent_traj_ids: list[str] = []
     segment_indices: list[int] = []
     raw_rewards: list[float] = []

--- a/dressage/rollout/multi_segment.py
+++ b/dressage/rollout/multi_segment.py
@@ -33,6 +33,41 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_NON_REAL_TOKEN_VERSIONS = {"", "-1", "none", "unknown"}
+
+
+def _real_token_version(value: Any) -> str | None:
+    if value is None:
+        return None
+    version = str(value).strip()
+    if version.lower() in _NON_REAL_TOKEN_VERSIONS:
+        return None
+    return version
+
+
+def _metric_trajectory_id(sample: Any) -> str | None:
+    meta = getattr(sample, "metadata", None) or {}
+    value = meta.get("parent_traj_id") or meta.get("session_id")
+    if value is not None:
+        return str(value)
+
+    rollout_id = getattr(sample, "rollout_id", None)
+    if rollout_id is not None:
+        return f"rollout:{rollout_id}"
+
+    index = getattr(sample, "index", None)
+    if index is not None:
+        return f"sample:{index}"
+
+    return None
+
+
+def _append_ordered_unique(target: list[str], values: list[Any]) -> None:
+    for value in values:
+        version = _real_token_version(value)
+        if version is not None and version not in target:
+            target.append(version)
+
 
 def mark_aborted_no_grad(
     sample: Any,
@@ -168,25 +203,47 @@ def compute_multi_segment_metrics(samples: list[Any]) -> dict[str, float]:
     so the metrics ride through ``RolloutFnTrainOutput.metrics``.
     """
     counts: dict[str, int] = {}
+    versions_by_traj: dict[str, list[str]] = {}
     for s in samples:
         if getattr(s, "remove_sample", False):
             continue
         meta = getattr(s, "metadata", None) or {}
         traj_id = meta.get("parent_traj_id")
+        metric_traj_id = _metric_trajectory_id(s)
+
         if traj_id is None:
-            continue
-        counts[traj_id] = counts.get(traj_id, 0) + 1
+            pass
+        else:
+            counts[traj_id] = counts.get(traj_id, 0) + 1
 
-    if not counts:
-        return {}
+        if metric_traj_id is not None and isinstance(meta.get("full_versions"), list):
+            versions = versions_by_traj.setdefault(metric_traj_id, [])
+            _append_ordered_unique(versions, meta["full_versions"])
 
-    values = list(counts.values())
-    n_traj = len(values)
-    total = sum(values)
-    return {
-        "rollout/segments_per_trajectory_mean": total / n_traj,
-        "rollout/segments_per_trajectory_max": float(max(values)),
-        "rollout/segments_per_trajectory_min": float(min(values)),
-        "rollout/num_trajectories": float(n_traj),
-        "rollout/num_segments": float(total),
-    }
+    metrics: dict[str, float] = {}
+
+    if counts:
+        values = list(counts.values())
+        n_traj = len(values)
+        total = sum(values)
+        metrics.update({
+            "rollout/segments_per_trajectory_mean": total / n_traj,
+            "rollout/segments_per_trajectory_max": float(max(values)),
+            "rollout/segments_per_trajectory_min": float(min(values)),
+            "rollout/num_trajectories": float(n_traj),
+            "rollout/num_segments": float(total),
+        })
+
+    version_spans = [
+        len(versions)
+        for versions in versions_by_traj.values()
+        if versions
+    ]
+    if version_spans:
+        metrics.update({
+            "staleness/version_span_mean": sum(version_spans) / len(version_spans),
+            "staleness/version_span_max": float(max(version_spans)),
+            "staleness/version_span_min": float(min(version_spans)),
+        })
+
+    return metrics

--- a/dressage/rollout/partial_async_rollout.py
+++ b/dressage/rollout/partial_async_rollout.py
@@ -34,6 +34,7 @@ from dressage.rollout.fully_async_rollout import (
     _allow_empty_train_batch,
     _flatten_multi_segment_result,
     _group_failure_summary,
+    _group_has_staleness_failure,
     _group_has_trainable_tokens,
     _increment_retry,
     _is_aborted_group,
@@ -397,6 +398,8 @@ async def generate_rollout_partial_async_impl(
     completed_by_id: dict[int, CompletedGroup] = {}
     data: list[list[Any]] = []
     dropped_failed_groups = 0
+    staleness_rejected_groups = 0
+    staleness_rejected_samples = 0
     dropped_failure_summaries: list[str] = []
     retried_groups = 0
     last_progress_time = time.time()
@@ -429,8 +432,16 @@ async def generate_rollout_partial_async_impl(
                 break
             completed = completed_by_id.pop(group_id)
             if completed.is_failed:
+                failed_group = completed.result or completed.original_group
+                staleness_failure = _group_has_staleness_failure(
+                    failed_group,
+                    completed.error,
+                )
+                if staleness_failure:
+                    staleness_rejected_groups += 1
+                    staleness_rejected_samples += len(completed.original_group)
                 summary = _group_failure_summary(
-                    completed.result or completed.original_group, completed.error
+                    failed_group, completed.error
                 )
                 if _retry_count(completed.original_group) < max_retries:
                     _increment_retry(completed.original_group)
@@ -530,6 +541,8 @@ async def generate_rollout_partial_async_impl(
         "dressage/partial_rollout_retried_groups": retried_groups,
         "dressage/partial_rollout_failed_groups": dropped_failed_groups,
         "dressage/partial_rollout_dropped_failed_groups": dropped_failed_groups,
+        "staleness/partial_rollout_rejected_groups": staleness_rejected_groups,
+        "staleness/partial_rollout_rejected_samples": staleness_rejected_samples,
         "dressage/partial_rollout_queued_completed_groups": worker.queued_completed_count(),
         "dressage/partial_rollout_final_worker_drain": int(drain_final_worker),
         "dressage/partial_rollout_drained_completed_groups": drained_completed_groups,

--- a/tests/blackbox_server/test_openclaw_adapter.py
+++ b/tests/blackbox_server/test_openclaw_adapter.py
@@ -15,6 +15,7 @@ from blackbox_server.adapters.base import (
     BackendContextOverflowError,
     BackendMaxStepsExceededError,
     BackendProtocolError,
+    BackendTransportError,
 )
 from blackbox_server.adapters.openclaw import (
     OpenClawAdapter,
@@ -42,6 +43,7 @@ class FakeProxy:
     def __init__(self) -> None:
         self.calls: list[tuple[str, object]] = []
         self.max_steps_payload: dict[str, Any] | None = None
+        self.rollout_invalidated_payload: dict[str, Any] | None = None
         self.max_steps_event = asyncio.Event()
 
     async def open_turn(self, turn_id: str, backend_session_id: str | None = None) -> None:
@@ -53,6 +55,14 @@ class FakeProxy:
     async def consume_context_overflow_error(self) -> dict[str, Any] | None:
         self.calls.append(("consume_context_overflow_error", None))
         return None
+
+    async def consume_rollout_invalidated_error(self) -> dict[str, Any] | None:
+        self.calls.append(("consume_rollout_invalidated_error", None))
+        if self.rollout_invalidated_payload is None:
+            return None
+        payload = dict(self.rollout_invalidated_payload)
+        self.rollout_invalidated_payload = None
+        return payload
 
     async def wait_for_max_steps_error(self, timeout: float | None = None) -> dict[str, Any] | None:
         if self.max_steps_payload is not None:
@@ -79,6 +89,9 @@ class FakeProxy:
     def trigger_max_steps_error(self, payload: dict[str, Any]) -> None:
         self.max_steps_payload = payload
         self.max_steps_event.set()
+
+    def trigger_rollout_invalidated_error(self, payload: dict[str, Any]) -> None:
+        self.rollout_invalidated_payload = payload
 
     async def clear_turn(self) -> None:
         self.calls.append(("clear", None))
@@ -645,8 +658,57 @@ def test_send_message_posts_chat_completion_payload_and_headers(tmp_path: Path) 
     assert adapter._proxy.calls[1][0] == "drain"
     assert isinstance(adapter._proxy.calls[1][1], float)
     assert adapter._proxy.calls[2] == ("consume_context_overflow_error", None)
-    assert adapter._proxy.calls[3] == ("drain", None)
-    assert adapter._proxy.calls[4] == ("clear", None)
+    assert adapter._proxy.calls[3] == ("consume_rollout_invalidated_error", None)
+    assert adapter._proxy.calls[4] == ("drain", None)
+    assert adapter._proxy.calls[5] == ("clear", None)
+
+
+def test_send_message_raises_proxy_rollout_invalidated_error(tmp_path: Path) -> None:
+    adapter = OpenClawAdapter()
+    adapter._binding_context = _make_binding_context(tmp_path)
+    adapter._options = _minimal_options()
+    adapter._gateway_token = "token-test"
+    adapter._proxy = FakeProxy()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        adapter._proxy.trigger_rollout_invalidated_error(
+            {
+                "error": "partial_rollout_staleness_exceeded",
+                "message": "Partial rollout model version span exceeded limit.",
+            }
+        )
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "choices": [{"message": {"role": "assistant", "content": ""}}],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            },
+        )
+
+    async def run_test() -> None:
+        adapter._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="http://openclaw.test",
+        )
+        session = _make_session_context()
+        with patch.object(adapter, "health", return_value=True):
+            with pytest.raises(
+                BackendTransportError,
+                match="partial_rollout_staleness_exceeded",
+            ):
+                await adapter.send_message(
+                    session,
+                    _make_turn_context("turn-1"),
+                    [Message(role="user", content="hello")],
+                )
+        await adapter._client.aclose()
+
+    asyncio.run(run_test())
+
+    assert ("consume_rollout_invalidated_error", None) in adapter._proxy.calls
+    assert ("clear", None) in adapter._proxy.calls
 
 
 def test_send_message_cancels_openclaw_chat_on_proxy_max_steps(tmp_path: Path) -> None:

--- a/tests/blackbox_server/test_rollout_llm_proxy.py
+++ b/tests/blackbox_server/test_rollout_llm_proxy.py
@@ -611,6 +611,29 @@ def test_rollout_proxy_hides_plain_dressage_rollout_invalidated_response():
     asyncio.run(run_test())
 
 
+def test_rollout_proxy_recognizes_partial_staleness_invalidated_response():
+    proxy = _make_proxy()
+    payload = {
+        "detail": {
+            "error": "partial_rollout_staleness_exceeded",
+            "message": "Partial rollout model version span exceeded limit.",
+            "session_id": "sess-001",
+            "versions": ["v1", "v2", "v3"],
+            "version_span": 3,
+            "version_switches": 2,
+            "max_preempts": 1,
+            "max_version_span": 2,
+        }
+    }
+
+    recorded = proxy._rollout_invalidated_payload_from_response(
+        status_code=502,
+        response_body=json.dumps(payload).encode("utf-8"),
+    )
+
+    assert recorded == payload["detail"]
+
+
 def test_rollout_proxy_hides_stream_dressage_rollout_invalidated_response():
     proxy = _make_proxy()
     payload = {

--- a/tests/test_log_rollout_data.py
+++ b/tests/test_log_rollout_data.py
@@ -9,10 +9,12 @@ math lives.
 
 from __future__ import annotations
 
+import sys
 from types import SimpleNamespace
 
 import pytest
 
+import dressage.rollout.log_rollout as log_rollout_module
 from dressage.rollout.log_rollout import log_rollout_data
 from dressage.training.log_helpers import compute_trajectory_mean_raw_reward
 
@@ -49,6 +51,26 @@ def test_rollout_hook_filters_no_loss_samples_from_trajectory_mean():
 
     assert log_rollout_data(0, SimpleNamespace(), samples, extra_metrics, 0.0) is False
     assert extra_metrics["rollout/raw_reward_trajectory_mean"] == pytest.approx(1.0)
+
+
+def test_rollout_hook_defines_staleness_wandb_step_metric(monkeypatch):
+    calls = []
+
+    class FakeWandb:
+        run = object()
+
+        @staticmethod
+        def define_metric(name, **kwargs):
+            calls.append((name, kwargs))
+
+    monkeypatch.setitem(sys.modules, "wandb", FakeWandb)
+    monkeypatch.setattr(log_rollout_module, "_STALENESS_WANDB_METRICS_DEFINED", False)
+
+    args = SimpleNamespace(use_wandb=True)
+    assert log_rollout_data(0, args, [], {}, 0.0) is False
+    assert log_rollout_data(1, args, [], {}, 0.0) is False
+
+    assert calls == [("staleness/*", {"step_metric": "rollout/step"})]
 
 
 def test_single_segment_trajectories():
@@ -135,4 +157,3 @@ def test_length_mismatch_raises():
         compute_trajectory_mean_raw_reward(["t1", "t2"], [1.0], [0, 0])
     with pytest.raises(ValueError):
         compute_trajectory_mean_raw_reward(["t1", "t2"], [1.0, 0.0], [0])
-

--- a/tests/test_multi_segment.py
+++ b/tests/test_multi_segment.py
@@ -324,10 +324,12 @@ def test_expand_rejects_duplicate_segment_index():
 # ---------------------------------------------------------------------------
 
 
-def _make_metric_sample(*, parent_traj_id=None, remove_sample=False):
+def _make_metric_sample(*, parent_traj_id=None, full_versions=None, remove_sample=False):
     meta: dict[str, Any] = {}
     if parent_traj_id is not None:
         meta["parent_traj_id"] = parent_traj_id
+    if full_versions is not None:
+        meta["full_versions"] = full_versions
     return SimpleNamespace(metadata=meta, remove_sample=remove_sample)
 
 
@@ -357,6 +359,21 @@ def test_compute_multi_segment_metrics_excludes_failures():
     metrics = compute_multi_segment_metrics(samples)
     assert metrics["rollout/num_trajectories"] == 1
     assert metrics["rollout/num_segments"] == 2
+
+
+def test_compute_multi_segment_metrics_reports_version_span():
+    samples = [
+        _make_metric_sample(parent_traj_id="t1", full_versions=["-1", "1", "1"]),
+        _make_metric_sample(parent_traj_id="t1", full_versions=["1", "2"]),
+        _make_metric_sample(parent_traj_id="t2", full_versions=["-1", "3"]),
+        _make_metric_sample(parent_traj_id="t3", full_versions=["4"], remove_sample=True),
+    ]
+
+    metrics = compute_multi_segment_metrics(samples)
+
+    assert metrics["staleness/version_span_mean"] == pytest.approx(1.5)
+    assert metrics["staleness/version_span_max"] == 2
+    assert metrics["staleness/version_span_min"] == 1
 
 
 def test_compute_multi_segment_metrics_empty():

--- a/tests/test_partial_async_rollout.py
+++ b/tests/test_partial_async_rollout.py
@@ -237,6 +237,51 @@ def test_partial_async_rollout_drops_exhausted_failed_group_and_keeps_collecting
     assert [group[0].index for group in result] == [1]
     assert result[0][0].status == SampleLike.Status.COMPLETED
 
+
+def test_partial_async_rollout_reports_staleness_rejected_groups(monkeypatch):
+    async def fake_generate_and_rm_group(args, group, sampling_params, evaluation=False):
+        del args, sampling_params, evaluation
+        sample = group[0]
+        if sample.index == 0:
+            sample.status = SampleLike.Status.ABORTED
+            sample.metadata["blackbox_error"] = (
+                "Dressage proxy error=partial_rollout_staleness_exceeded "
+                "version_span=3 max_version_span=2"
+            )
+            sample.session_id = None
+            return group
+
+        sample.status = SampleLike.Status.COMPLETED
+        sample.reward = 1.0
+        sample.tokens = [1, 2]
+        sample.response_length = 1
+        sample.loss_mask = [1]
+        sample.rollout_log_probs = [-0.1]
+        return group
+
+    class TrainOutput:
+        def __init__(self, samples, metrics=None):
+            self.samples = samples
+            self.metrics = metrics or {}
+
+    monkeypatch.setattr(partial_async_rollout, "generate_and_rm_group", fake_generate_and_rm_group)
+    monkeypatch.setattr(partial_async_rollout, "GenerateState", None)
+    monkeypatch.setattr(partial_async_rollout, "RolloutFnTrainOutput", TrainOutput)
+    monkeypatch.setenv("DRESSAGE_ASYNC_MAX_ACTIVE_GROUPS", "1")
+    monkeypatch.setenv("DRESSAGE_PARTIAL_ROLLOUT_TARGET_GROUPS", "1")
+    monkeypatch.setenv("DRESSAGE_ROLLOUT_MAX_RETRIES", "0")
+    monkeypatch.setenv("DRESSAGE_ASYNC_MAX_DROPPED_FAILED_GROUPS", "10")
+
+    data = DataBuffer([[SampleLike(index=0)], [SampleLike(index=1)]])
+    args = SimpleNamespace(rollout_batch_size=1, n_samples_per_prompt=1, global_batch_size=1)
+
+    output = partial_async_rollout.generate_rollout_partial_async(args, 0, data)
+
+    assert _samples(output)[0][0].index == 1
+    assert output.metrics["staleness/partial_rollout_rejected_groups"] == 1
+    assert output.metrics["staleness/partial_rollout_rejected_samples"] == 1
+
+
 def test_partial_async_rollout_drains_worker_after_final_rollout(monkeypatch):
     async def fake_generate_and_rm_group(args, group, sampling_params, evaluation=False):
         del args, sampling_params, evaluation

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -736,6 +736,8 @@ def make_client(
     context_window: int | None = None,
     dynamic_max_tokens: bool = True,
     use_rollout_routing_replay: bool = False,
+    partial_rollout: bool = False,
+    max_partial_rollout_preempts: int | None = None,
 ):
     session_manager = SessionManager()
     trajectory_store = TrajectoryStore(min_group_size=1, group_timeout=0.0)
@@ -761,6 +763,8 @@ def make_client(
         context_window=context_window,
         dynamic_max_tokens=dynamic_max_tokens,
         use_rollout_routing_replay=use_rollout_routing_replay,
+        partial_rollout=partial_rollout,
+        max_partial_rollout_preempts=max_partial_rollout_preempts,
     )
     if tool_call_parser is not _UNSET:
         create_app_kwargs["tool_call_parser"] = tool_call_parser
@@ -1070,6 +1074,21 @@ def test_parse_args_can_disable_dynamic_max_tokens(monkeypatch):
     )
 
     assert parse_args().dynamic_max_tokens is False
+
+
+def test_parse_args_accepts_max_partial_rollout_preempts(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "dressage.proxy.server",
+            "--tokenizer-path",
+            "fake-tokenizer",
+            "--max-partial-rollout-preempts",
+            "0",
+        ],
+    )
+
+    assert parse_args().max_partial_rollout_preempts == 0
 
 
 def test_chat_completion_context_window_input_overflow_skips_sglang():
@@ -3213,6 +3232,44 @@ def test_non_partial_session_rejects_stale_epoch_before_sglang():
     session = session_manager.get_session("sess-cross-version")
     assert session is not None
     assert len(session.steps) == 1
+
+
+def test_partial_rollout_rejects_staleness_exceeded():
+    first = make_response("a", finish_reason="abort", output_logprobs=[-0.11])
+    first.meta_info = {"finish_reason": {"type": "abort"}, "weight_version": "v1"}
+    second = make_response("b", finish_reason="abort", output_logprobs=[-0.22])
+    second.meta_info = {"finish_reason": {"type": "abort"}, "weight_version": "v2"}
+    third = make_response("c", output_logprobs=[-0.33])
+    third.meta_info = {"finish_reason": {"type": "stop"}, "weight_version": "v3"}
+    client, session_manager, _, sglang_client = make_client(
+        first,
+        second,
+        third,
+        partial_rollout=True,
+        max_partial_rollout_preempts=1,
+    )
+
+    response = client.post(
+        "/v1/chat/completions",
+        headers={
+            "X-Session-Id": "sess-staleness",
+            "X-Instance-Id": "inst-staleness",
+        },
+        json={"model": "fake-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.status_code == 502
+    detail = response.json()["detail"]
+    assert detail["error"] == "partial_rollout_staleness_exceeded"
+    assert detail["versions"] == ["v1", "v2", "v3"]
+    assert detail["version_span"] == 3
+    assert detail["version_switches"] == 2
+    assert detail["max_preempts"] == 1
+    assert detail["max_version_span"] == 2
+    assert len(sglang_client.calls) == 3
+    session = session_manager.get_session("sess-staleness")
+    assert session is not None
+    assert len(session.steps) == 0
 
 
 def test_non_partial_first_step_waiting_for_resume_binds_generated_epoch():

--- a/tests/test_rollout_helper_modules.py
+++ b/tests/test_rollout_helper_modules.py
@@ -390,6 +390,31 @@ def _http_status_error(
         response = httpx.Response(status_code, json=json_body, request=request)
     return httpx.HTTPStatusError("request failed", request=request, response=response)
 
+def test_blackbox_failures_record_abort_includes_http_response_body():
+    metadata = {"dressage_retry_count": 1}
+    request = httpx.Request("POST", "http://proxy/v1/chat/completions")
+    response = httpx.Response(
+        502,
+        json={
+            "detail": {
+                "error": "partial_rollout_staleness_exceeded",
+                "version_span": 3,
+            }
+        },
+        request=request,
+    )
+    exc = httpx.HTTPStatusError("bad gateway", request=request, response=response)
+
+    record_blackbox_abort_for_retry(metadata, "bbs-sess", exc)
+
+    assert "partial_rollout_staleness_exceeded" in metadata["blackbox_error"]
+    assert metadata["blackbox_http_status_code"] == 502
+    assert "partial_rollout_staleness_exceeded" in metadata["blackbox_http_response_body"]
+    assert metadata["blackbox_http_response_json"]["detail"]["version_span"] == 3
+    history = metadata["blackbox_failure_history"][0]
+    assert "partial_rollout_staleness_exceeded" in history["error"]
+    assert "partial_rollout_staleness_exceeded" in history["http_response_body"]
+
 
 def test_execute_hooks_run_stage_and_record_optional_http_failure():
     asyncio.run(_run_execute_hooks_run_stage_and_record_optional_http_failure())


### PR DESCRIPTION
## Summary

This PR adds rollout-side data staleness control for Dressage partial rollout. It introduces `--max-partial-rollout-preempts`, allowing users to configure how many model weight-version switches a trajectory may span during partial rollout. If the trajectory exceeds the configured threshold, Dressage rejects it on the rollout side instead of using overly stale data for training.

## Changes

Add partial rollout staleness control:

- Add `--max-partial-rollout-preempts`.
- Track trajectory model-version span from recorded token versions.
- Reject trajectories whose version switches exceed the configured threshold.
- Prevent overly stale partial-rollout data from entering training.

Add W&B staleness metrics:

- Add `staleness/version_span_mean`.
- Add `staleness/version_span_max`.
- Add `staleness/version_span_min`.
- Add `staleness/partial_rollout_rejected_groups`.
- Add `staleness/partial_rollout_rejected_samples`.

## Validation

- `git diff --check release/main...HEAD`
- Python compile check for updated proxy, rollout, blackbox, and test modules
- `/tmp/dressage-validation-venv/bin/python -m pytest tests/test_partial_async_rollout.py tests/test_log_rollout_data.py tests/test_multi_segment.py`

Result: `54 passed`