### PR TITLE
feat: support async call_agent for BlackboxServer

### DIFF
--- a/blackbox_server/api/sessions.py
+++ b/blackbox_server/api/sessions.py
@@ -1,25 +1,78 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Query, Request
+from fastapi.responses import JSONResponse
 
+from blackbox_server.core.errors import ApiError
 from blackbox_server.core.models import (
     AbortResponse,
     ExecuteCmdRequest,
     ExecuteCmdResponse,
     MessageRequest,
-    MessageResponse,
     SessionResponse,
+    TurnCancelResponse,
+    TurnStatusResponse,
+    TurnSubmitResponse,
 )
 
 
 router = APIRouter()
 
 
-@router.post("/v1/sessions/{session_id}/messages", response_model=MessageResponse)
-async def send_message(session_id: str, request: Request, payload: MessageRequest) -> MessageResponse:
+@router.post("/v1/sessions/{session_id}/messages")
+async def send_message(session_id: str, request: Request, payload: MessageRequest):
     server = request.app.state.server
+    if payload.mode == "async":
+        if payload.turn_id is None:
+            raise ApiError(
+                400,
+                "request_error",
+                "turn_id is required for async submissions.",
+                details={"session_id": session_id},
+            )
+        async with server.request_scope():
+            submission = await server.submit_turn(session_id, payload)
+        response = TurnSubmitResponse(
+            request_id=request.state.request_id,
+            session_id=session_id,
+            instance_id=submission.instance_id,
+            turn_id=submission.turn_id,
+            status=submission.status,
+            idempotent_replay=submission.idempotent_replay,
+        )
+        return JSONResponse(status_code=202, content=response.model_dump(mode="json"))
+
     async with server.request_scope():
         response = await server.send_message(session_id, payload)
+    response.request_id = request.state.request_id
+    return response
+
+
+@router.get(
+    "/v1/sessions/{session_id}/turns/{turn_id}",
+    response_model=TurnStatusResponse,
+)
+async def get_turn(
+    session_id: str,
+    turn_id: str,
+    request: Request,
+    wait: float = Query(default=0.0, ge=0.0),
+) -> TurnStatusResponse:
+    server = request.app.state.server
+    async with server.request_scope():
+        response = await server.get_turn(session_id, turn_id, wait_seconds=wait)
+    response.request_id = request.state.request_id
+    return response
+
+
+@router.post(
+    "/v1/sessions/{session_id}/turns/{turn_id}/cancel",
+    response_model=TurnCancelResponse,
+)
+async def cancel_turn(session_id: str, turn_id: str, request: Request) -> TurnCancelResponse:
+    server = request.app.state.server
+    async with server.request_scope():
+        response = await server.cancel_turn(session_id, turn_id)
     response.request_id = request.state.request_id
     return response
 

--- a/blackbox_server/core/models.py
+++ b/blackbox_server/core/models.py
@@ -33,9 +33,12 @@ class SessionState(str, Enum):
 
 
 class TurnStatus(str, Enum):
-    INFLIGHT = "inflight"
-    COMMITTED = "committed"
-    UNKNOWN = "unknown"
+    QUEUED = "queued"        # accepted, not started yet
+    INFLIGHT = "inflight"    # backend call in flight
+    COMMITTED = "committed"  # succeeded
+    FAILED = "failed"        # deterministic failure (session not necessarily desynced)
+    CANCELLED = "cancelled"  # cancellation completed
+    UNKNOWN = "unknown"      # result unknown (timeout/process error); session -> DESYNCED
 
 
 class FunctionCall(BaseModel):
@@ -219,6 +222,7 @@ class MessageRequest(BaseModel):
     turn_id: str | None = None
     messages: list[Message]
     metadata: dict[str, Any] = Field(default_factory=dict)
+    mode: Literal["sync", "async"] = "sync"
 
 
 class MessageResponse(BaseModel):
@@ -231,6 +235,45 @@ class MessageResponse(BaseModel):
     outputs: list[Message]
     backend: BackendRef
     usage: TurnUsage
+
+
+class TurnSubmitResponse(BaseModel):
+    """202 Accepted response returned when a turn is submitted in async mode."""
+
+    request_id: str = ""
+    session_id: str
+    instance_id: str | None = None
+    turn_id: str
+    status: TurnStatus
+    idempotent_replay: bool = False
+
+
+class TurnStatusResponse(BaseModel):
+    """Snapshot returned by the long-poll turn status endpoint."""
+
+    request_id: str = ""
+    session_id: str
+    instance_id: str | None = None
+    turn_id: str
+    status: TurnStatus
+    state: SessionState
+    outputs: list[Message] | None = None
+    usage: TurnUsage | None = None
+    backend: BackendRef | None = None
+    error: dict[str, Any] | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class TurnCancelResponse(BaseModel):
+    """Response returned by the turn cancel endpoint."""
+
+    request_id: str = ""
+    session_id: str
+    instance_id: str | None = None
+    turn_id: str
+    status: str
+    state: SessionState
 
 
 class ExecuteCmdRequest(BaseModel):

--- a/blackbox_server/core/server.py
+++ b/blackbox_server/core/server.py
@@ -7,6 +7,7 @@ import os
 import re
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -59,9 +60,12 @@ from blackbox_server.core.models import (
     SessionStats,
     StatusResponse,
     TraceEvent,
+    TurnCancelResponse,
     TurnContext,
     TurnRecord,
     TurnStatus,
+    TurnStatusResponse,
+    TurnSubmitResponse,
     utcnow,
 )
 from blackbox_server.core.monitoring import BackendMonitor
@@ -80,6 +84,26 @@ _TURN_MODE_KEY = "__bbs_turn_mode"
 _TURN_MODE_SINGLE = "single"
 _TURN_MODE_EXPLICIT = "explicit"
 _DEFAULT_TURN_ID_KEY = "__bbs_default_turn_id"
+_ACTIVE_TURN_STATUSES = frozenset({TurnStatus.QUEUED, TurnStatus.INFLIGHT})
+_TERMINAL_TURN_STATUSES = frozenset(
+    {
+        TurnStatus.COMMITTED,
+        TurnStatus.FAILED,
+        TurnStatus.CANCELLED,
+        TurnStatus.UNKNOWN,
+    }
+)
+_MAX_TURN_WAIT_SECONDS = 60.0
+
+
+@dataclass
+class TurnSubmission:
+    """Result of accepting (or replaying) a turn submission."""
+
+    turn_id: str
+    status: TurnStatus
+    idempotent_replay: bool
+    instance_id: str | None = None
 
 
 class BlackboxServer:
@@ -95,6 +119,8 @@ class BlackboxServer:
         self._session_store = SessionStore()
         self._monitor: BackendMonitor | None = None
         self._active_cmd_processes: dict[str, asyncio.subprocess.Process] = {}
+        self._turn_events: dict[tuple[str, str], asyncio.Event] = {}
+        self._active_turn_tasks: dict[str, asyncio.Task[None]] = {}
         self._active_requests = 0
         self._request_counter_lock = asyncio.Lock()
         self._no_inflight_requests = asyncio.Event()
@@ -197,6 +223,7 @@ class BlackboxServer:
         self._shutdown_started = True
         self._state = ServerState.SHUTTING_DOWN
         await self._terminate_all_active_cmds()
+        await self._terminate_all_active_turns()
         try:
             await asyncio.wait_for(
                 self._no_inflight_requests.wait(),
@@ -382,7 +409,13 @@ class BlackboxServer:
             "adapter": adapter_state,
         }
 
-    async def send_message(self, session_id: str, request: MessageRequest) -> MessageResponse:
+    async def submit_turn(self, session_id: str, request: MessageRequest) -> TurnSubmission:
+        """Accept (or idempotently replay) a turn and start background execution.
+
+        Runs the short admission critical section under ``session_lock`` and then
+        releases the lock, spawning ``_run_turn`` for the actual backend call.
+        """
+
         self._ensure_state_ready_for_messages()
         await self._wait_if_paused()
         self._validate_identifier("session_id", session_id)
@@ -445,33 +478,31 @@ class BlackboxServer:
                         "Same turn_id was already used with a different request body.",
                         details={"session_id": session_id, "turn_id": effective_turn_id},
                     )
-                if existing.status == TurnStatus.COMMITTED and existing.response is not None:
-                    return MessageResponse(
-                        request_id="",
-                        session_id=session_id,
-                        instance_id=self._response_instance_id(),
-                        turn_id=effective_turn_id,
-                        state=session.state,
-                        idempotent_replay=True,
-                        outputs=existing.response.outputs,
-                        backend=BackendRef(
-                            type=self._binding_context.binding.blackbox_type,
-                            backend_session_id=existing.response.backend_session_id,
-                        ),
-                        usage=existing.response.usage,
-                    )
-                if existing.status == TurnStatus.INFLIGHT:
-                    raise ApiError(
-                        409,
-                        "conflict",
-                        "Same turn_id is still in flight.",
-                        details={"session_id": session_id, "turn_id": effective_turn_id},
-                    )
+                # Same turn_id + same fingerprint: idempotent replay of the
+                # existing record regardless of its state.  COMMITTED replays the
+                # result, QUEUED/INFLIGHT re-attach to the same execution, and the
+                # remaining terminal states are returned as-is for the client to
+                # decide the next step.
+                return TurnSubmission(
+                    turn_id=effective_turn_id,
+                    status=existing.status,
+                    idempotent_replay=True,
+                    instance_id=self._response_instance_id(),
+                )
+
+            # Distinct turn_id while another turn is still active: at most one
+            # active turn per session.
+            active_turn_id = self._active_turn_id(session)
+            if active_turn_id is not None:
                 raise ApiError(
                     409,
                     "conflict",
-                    "Same turn_id is in unknown state and the session is desynced.",
-                    details={"session_id": session_id, "turn_id": effective_turn_id},
+                    "Session already has an active turn in progress.",
+                    details={
+                        "session_id": session_id,
+                        "turn_id": effective_turn_id,
+                        "active_turn_id": active_turn_id,
+                    },
                 )
 
             if not await self._adapter_health_with_retry("before_send_message"):
@@ -482,109 +513,303 @@ class BlackboxServer:
             session.turn_ledger[effective_turn_id] = TurnRecord(
                 turn_id=effective_turn_id,
                 request_fingerprint=request_fingerprint,
-                status=TurnStatus.INFLIGHT,
+                status=TurnStatus.QUEUED,
                 request_messages=request.messages,
                 created_at=now,
                 updated_at=now,
             )
+            self._turn_events[(bound_session_id, effective_turn_id)] = asyncio.Event()
+            task = asyncio.create_task(
+                self._run_turn(bound_session_id, effective_turn_id, request)
+            )
+            self._active_turn_tasks[bound_session_id] = task
+            return TurnSubmission(
+                turn_id=effective_turn_id,
+                status=TurnStatus.QUEUED,
+                idempotent_replay=False,
+                instance_id=self._response_instance_id(),
+            )
+
+    async def send_message(self, session_id: str, request: MessageRequest) -> MessageResponse:
+        """Synchronous facade: submit a turn and block until it settles.
+
+        Preserves the exact HTTP status codes / error semantics of the original
+        request-bound implementation by reconstructing them from the turn record.
+        """
+
+        submission = await self.submit_turn(session_id, request)
+        bound_session_id = self._binding_context.binding.bound_session_id
+
+        if submission.status in _ACTIVE_TURN_STATUSES:
+            event = self._turn_events.get((bound_session_id, submission.turn_id))
+            if event is not None:
+                await event.wait()
+
+        session = await self._session_store.get(bound_session_id)
+        session_lock = await self._session_store.get_lock(bound_session_id)
+        if session is None or session_lock is None:
+            raise ApiError(
+                500,
+                "internal_error",
+                "Bound session was not initialized.",
+                details={"session_id": bound_session_id},
+            )
+
+        async with session_lock:
+            record = session.turn_ledger.get(submission.turn_id)
+            if record is None:
+                raise ApiError(
+                    500,
+                    "internal_error",
+                    "Turn record disappeared before completion.",
+                    details={"session_id": session_id, "turn_id": submission.turn_id},
+                )
+            if record.status == TurnStatus.COMMITTED and record.response is not None:
+                return self._build_committed_message_response(
+                    session_id=session_id,
+                    session=session,
+                    record=record,
+                    idempotent_replay=submission.idempotent_replay,
+                )
+            self._raise_from_turn_error(session_id, record)
+
+    async def _run_turn(
+        self,
+        session_id: str,
+        turn_id: str,
+        request: MessageRequest,
+    ) -> None:
+        """Background execution of a submitted turn (does not hold session_lock)."""
+
+        session = await self._session_store.get(session_id)
+        session_lock = await self._session_store.get_lock(session_id)
+        try:
+            if session is None or session_lock is None:
+                return
+
+            async with session_lock:
+                record = session.turn_ledger.get(turn_id)
+                if record is None or record.status != TurnStatus.QUEUED:
+                    return
+                record.status = TurnStatus.INFLIGHT
+                record.updated_at = utcnow()
 
             turn_context = TurnContext(
-                turn_id=effective_turn_id,
-                request_fingerprint=request_fingerprint,
+                turn_id=turn_id,
+                request_fingerprint=record.request_fingerprint,
                 metadata=request.metadata,
                 deadline_seconds=self._effective_config.backend_timeout,
             )
+
+            outcome: tuple[str, Any, dict[str, Any] | None]
             try:
                 adapter_response = await self._wait_for_backend_call_excluding_pause(
                     self._adapter.send_message(session, turn_context, request.messages),
                     timeout=self._effective_config.backend_timeout,
                 )
-                session.backend_session_id = adapter_response.backend_session_id
-                session.conversation_history.extend(request.messages)
-                session.conversation_history.extend(adapter_response.outputs)
-                session.trace_events.extend(adapter_response.trace_events)
-                session.turn_count += 1
-                session.updated_at = utcnow()
-                turn_record = session.turn_ledger[effective_turn_id]
-                turn_record.status = TurnStatus.COMMITTED
-                turn_record.response = adapter_response
-                turn_record.updated_at = utcnow()
-                return MessageResponse(
-                    request_id="",
-                    session_id=session_id,
-                    instance_id=self._response_instance_id(),
-                    turn_id=effective_turn_id,
-                    state=session.state,
-                    idempotent_replay=False,
-                    outputs=adapter_response.outputs,
-                    backend=BackendRef(
-                        type=self._binding_context.binding.blackbox_type,
-                        backend_session_id=adapter_response.backend_session_id,
-                    ),
-                    usage=adapter_response.usage,
+                outcome = ("commit", adapter_response, None)
+            except asyncio.CancelledError:
+                async with session_lock:
+                    self._finalize_interrupted_turn_locked(session, turn_id)
+                return
+            except asyncio.TimeoutError:
+                outcome = (
+                    "unknown",
+                    None,
+                    {
+                        "error": "backend_timeout",
+                        "message": "Backend call exceeded backend_timeout.",
+                        "http_status": 504,
+                    },
                 )
-            except asyncio.TimeoutError as exc:
-                await self._handle_unknown_turn(
-                    session=session,
-                    turn_id=effective_turn_id,
-                    error="backend_timeout",
-                    message="Backend call exceeded backend_timeout.",
-                )
-                raise ApiError(
-                    504,
-                    "backend_timeout",
-                    "Backend call exceeded backend_timeout.",
-                    details={"session_id": session_id, "turn_id": effective_turn_id},
-                ) from exc
             except BackendContextOverflowError as exc:
-                await self._handle_unknown_turn(
-                    session=session,
-                    turn_id=effective_turn_id,
-                    error="context_overflow",
-                    message=str(exc),
-                )
-                raise ApiError(
-                    413,
-                    "context_overflow",
-                    str(exc),
-                    details={
-                        "session_id": session_id,
-                        "turn_id": effective_turn_id,
-                        **exc.details(),
+                outcome = (
+                    "unknown",
+                    None,
+                    {
+                        "error": "context_overflow",
+                        "message": str(exc),
+                        "http_status": 413,
+                        "extra_details": exc.details(),
                     },
-                ) from exc
+                )
             except BackendMaxStepsExceededError as exc:
-                await self._handle_unknown_turn(
-                    session=session,
-                    turn_id=effective_turn_id,
-                    error="max_steps_exceeded",
-                    message=str(exc),
-                )
-                raise ApiError(
-                    429,
-                    "max_steps_exceeded",
-                    str(exc),
-                    details={
-                        "session_id": session_id,
-                        "turn_id": effective_turn_id,
-                        **exc.details(),
+                outcome = (
+                    "unknown",
+                    None,
+                    {
+                        "error": "max_steps_exceeded",
+                        "message": str(exc),
+                        "http_status": 429,
+                        "extra_details": exc.details(),
                     },
-                ) from exc
-            except (BackendTransportError, BackendProtocolError, BackendProcessError) as exc:
-                await self._handle_unknown_turn(
-                    session=session,
-                    turn_id=effective_turn_id,
-                    error="backend_error",
-                    message=str(exc),
                 )
-                if isinstance(exc, BackendProcessError):
-                    await self._mark_backend_error("backend_process_error")
+            except (BackendTransportError, BackendProtocolError, BackendProcessError) as exc:
+                outcome = (
+                    "unknown",
+                    None,
+                    {
+                        "error": "backend_error",
+                        "message": f"Backend request failed: {exc}",
+                        "http_status": 502,
+                        "process_error": isinstance(exc, BackendProcessError),
+                    },
+                )
+            except Exception as exc:
+                LOGGER.exception(
+                    "unexpected error while running turn %s for session %s",
+                    turn_id,
+                    session_id,
+                )
+                outcome = (
+                    "unknown",
+                    None,
+                    {
+                        "error": "internal_error",
+                        "message": f"Unexpected backend failure: {exc}",
+                        "http_status": 500,
+                    },
+                )
+
+            async with session_lock:
+                record = session.turn_ledger.get(turn_id)
+                if record is None or record.status != TurnStatus.INFLIGHT:
+                    # Turn was aborted/cancelled concurrently; do not commit.
+                    return
+                if outcome[0] == "commit":
+                    adapter_response = outcome[1]
+                    session.backend_session_id = adapter_response.backend_session_id
+                    session.conversation_history.extend(request.messages)
+                    session.conversation_history.extend(adapter_response.outputs)
+                    session.trace_events.extend(adapter_response.trace_events)
+                    session.turn_count += 1
+                    session.updated_at = utcnow()
+                    record.status = TurnStatus.COMMITTED
+                    record.response = adapter_response
+                    record.updated_at = utcnow()
+                else:
+                    error_kwargs = dict(outcome[2] or {})
+                    process_error = bool(error_kwargs.pop("process_error", False))
+                    await self._handle_unknown_turn(
+                        session=session,
+                        turn_id=turn_id,
+                        error=error_kwargs["error"],
+                        message=error_kwargs["message"],
+                        http_status=error_kwargs.get("http_status"),
+                        extra_details=error_kwargs.get("extra_details"),
+                    )
+                    if process_error:
+                        await self._mark_backend_error("backend_process_error")
+        finally:
+            event = self._turn_events.get((session_id, turn_id))
+            if event is not None:
+                event.set()
+            current = asyncio.current_task()
+            if self._active_turn_tasks.get(session_id) is current:
+                self._active_turn_tasks.pop(session_id, None)
+
+    async def get_turn(
+        self,
+        session_id: str,
+        turn_id: str,
+        *,
+        wait_seconds: float = 0.0,
+    ) -> TurnStatusResponse:
+        self._validate_identifier("session_id", session_id)
+        self._validate_identifier("turn_id", turn_id)
+        bound_session_id = self._require_bound_session_match(session_id)
+        session = await self._session_store.get(bound_session_id) if bound_session_id else None
+        session_lock = (
+            await self._session_store.get_lock(bound_session_id) if bound_session_id else None
+        )
+        if session is None or session_lock is None:
+            raise ApiError(404, "not_found", "Session does not exist.", details={"session_id": session_id})
+
+        record = session.turn_ledger.get(turn_id)
+        if record is None:
+            raise ApiError(
+                404,
+                "not_found",
+                "Turn does not exist.",
+                details={"session_id": session_id, "turn_id": turn_id},
+            )
+
+        if wait_seconds and wait_seconds > 0 and record.status in _ACTIVE_TURN_STATUSES:
+            clamped = min(float(wait_seconds), _MAX_TURN_WAIT_SECONDS)
+            event = self._turn_events.get((bound_session_id, turn_id))
+            if event is not None:
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(event.wait(), timeout=clamped)
+
+        async with session_lock:
+            record = session.turn_ledger.get(turn_id)
+            if record is None:
                 raise ApiError(
-                    502,
-                    "backend_error",
-                    f"Backend request failed: {exc}",
-                    details={"session_id": session_id, "turn_id": effective_turn_id},
-                ) from exc
+                    404,
+                    "not_found",
+                    "Turn does not exist.",
+                    details={"session_id": session_id, "turn_id": turn_id},
+                )
+            return self._build_turn_status_response(session_id, session, record)
+
+    async def cancel_turn(self, session_id: str, turn_id: str) -> TurnCancelResponse:
+        self._validate_identifier("session_id", session_id)
+        self._validate_identifier("turn_id", turn_id)
+        bound_session_id = self._require_bound_session_match(session_id)
+        session = await self._session_store.get(bound_session_id) if bound_session_id else None
+        session_lock = (
+            await self._session_store.get_lock(bound_session_id) if bound_session_id else None
+        )
+        if session is None or session_lock is None:
+            raise ApiError(404, "not_found", "Session does not exist.", details={"session_id": session_id})
+
+        cancel_inflight = False
+        async with session_lock:
+            record = session.turn_ledger.get(turn_id)
+            if record is None:
+                raise ApiError(
+                    404,
+                    "not_found",
+                    "Turn does not exist.",
+                    details={"session_id": session_id, "turn_id": turn_id},
+                )
+            if record.status == TurnStatus.QUEUED:
+                record.status = TurnStatus.CANCELLED
+                record.error = {
+                    "error": "cancelled",
+                    "message": "Turn cancelled before execution.",
+                    "http_status": 499,
+                    "details": {"session_id": session_id, "turn_id": turn_id},
+                }
+                record.updated_at = utcnow()
+                session.updated_at = utcnow()
+                event = self._turn_events.get((bound_session_id, turn_id))
+                if event is not None:
+                    event.set()
+                status = "cancelled"
+            elif record.status == TurnStatus.INFLIGHT:
+                cancel_inflight = True
+                status = "cancel_requested"
+            else:
+                status = record.status.value
+            state = session.state
+
+        if cancel_inflight:
+            task = self._active_turn_tasks.get(bound_session_id)
+            if task is not None:
+                task.cancel()
+            if self._adapter is not None:
+                with contextlib.suppress(Exception):
+                    await self._adapter.abort_session(session)
+
+        return TurnCancelResponse(
+            request_id="",
+            session_id=session_id,
+            instance_id=self._response_instance_id(),
+            turn_id=turn_id,
+            status=status,
+            state=state,
+        )
 
     async def execute_cmd(self, session_id: str, request: ExecuteCmdRequest) -> ExecuteCmdResponse:
         self._ensure_state_ready_for_messages()
@@ -627,6 +852,14 @@ class BlackboxServer:
                     "conflict",
                     "Session is desynced and cannot execute commands.",
                     details={"session_id": session_id, "state": session.state},
+                )
+            active_turn_id = self._active_turn_id(session)
+            if active_turn_id is not None:
+                raise ApiError(
+                    409,
+                    "conflict",
+                    "Session has an active turn in progress and cannot execute commands.",
+                    details={"session_id": session_id, "active_turn_id": active_turn_id},
                 )
 
             try:
@@ -711,6 +944,10 @@ class BlackboxServer:
                     mode="noop",
                 )
 
+            active_turn_task = self._active_turn_tasks.get(session_id)
+            if active_turn_task is not None:
+                active_turn_task.cancel()
+
             if self._adapter is not None:
                 with contextlib.suppress(Exception):
                     await self._adapter.abort_session(session)
@@ -720,10 +957,18 @@ class BlackboxServer:
 
             now = utcnow()
             for turn_record in session.turn_ledger.values():
-                if turn_record.status == TurnStatus.INFLIGHT:
+                if turn_record.status in _ACTIVE_TURN_STATUSES:
                     turn_record.status = TurnStatus.UNKNOWN
-                    turn_record.error = {"error": "aborted", "message": "Session was aborted while turn was in flight."}
+                    turn_record.error = {
+                        "error": "aborted",
+                        "message": "Session was aborted while turn was in flight.",
+                        "http_status": 409,
+                        "details": {"session_id": session_id, "turn_id": turn_record.turn_id},
+                    }
                     turn_record.updated_at = now
+                    event = self._turn_events.get((session_id, turn_record.turn_id))
+                    if event is not None:
+                        event.set()
 
             return AbortResponse(
                 request_id="",
@@ -749,6 +994,126 @@ class BlackboxServer:
             known_backends=KNOWN_BACKENDS,
         )
 
+    @staticmethod
+    def _active_turn_id(session: SessionContext) -> str | None:
+        for record in session.turn_ledger.values():
+            if record.status in _ACTIVE_TURN_STATUSES:
+                return record.turn_id
+        return None
+
+    def _build_committed_message_response(
+        self,
+        *,
+        session_id: str,
+        session: SessionContext,
+        record: TurnRecord,
+        idempotent_replay: bool,
+    ) -> MessageResponse:
+        assert record.response is not None
+        assert self._binding_context is not None
+        return MessageResponse(
+            request_id="",
+            session_id=session_id,
+            instance_id=self._response_instance_id(),
+            turn_id=record.turn_id,
+            state=session.state,
+            idempotent_replay=idempotent_replay,
+            outputs=record.response.outputs,
+            backend=BackendRef(
+                type=self._binding_context.binding.blackbox_type,
+                backend_session_id=record.response.backend_session_id,
+            ),
+            usage=record.response.usage,
+        )
+
+    def _raise_from_turn_error(self, session_id: str, record: TurnRecord) -> None:
+        """Reconstruct the original synchronous ApiError from a turn record."""
+
+        error = record.error or {}
+        http_status = int(error.get("http_status") or 500)
+        code = str(error.get("error") or "backend_error")
+        message = str(error.get("message") or "Turn failed.")
+        details = error.get("details")
+        if not isinstance(details, dict):
+            details = {"session_id": session_id, "turn_id": record.turn_id}
+        raise ApiError(http_status, code, message, details=details)
+
+    def _build_turn_status_response(
+        self,
+        session_id: str,
+        session: SessionContext,
+        record: TurnRecord,
+    ) -> TurnStatusResponse:
+        outputs = None
+        usage = None
+        backend = None
+        error = None
+        if record.status == TurnStatus.COMMITTED and record.response is not None:
+            outputs = record.response.outputs
+            usage = record.response.usage
+            assert self._binding_context is not None
+            backend = BackendRef(
+                type=self._binding_context.binding.blackbox_type,
+                backend_session_id=record.response.backend_session_id,
+            )
+        elif record.status in _TERMINAL_TURN_STATUSES:
+            error = record.error
+        return TurnStatusResponse(
+            request_id="",
+            session_id=session_id,
+            instance_id=self._response_instance_id(),
+            turn_id=record.turn_id,
+            status=record.status,
+            state=session.state,
+            outputs=outputs,
+            usage=usage,
+            backend=backend,
+            error=error,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+        )
+
+    def _finalize_interrupted_turn_locked(self, session: SessionContext, turn_id: str) -> None:
+        """Settle a turn interrupted by cancellation or shutdown.
+
+        Must be called while holding the session lock.  During shutdown the turn
+        is treated as UNKNOWN (session -> DESYNCED, mirroring the timeout path);
+        an explicit cancel maps to CANCELLED.
+        """
+
+        record = session.turn_ledger.get(turn_id)
+        if record is None or record.status in _TERMINAL_TURN_STATUSES:
+            return
+        now = utcnow()
+        if self._shutdown_started:
+            record.status = TurnStatus.UNKNOWN
+            record.error = {
+                "error": "server_shutdown",
+                "message": "Server shut down while the turn was in flight.",
+                "http_status": 504,
+                "details": {"session_id": session.session_id, "turn_id": turn_id},
+            }
+            if session.state != SessionState.ABORTED:
+                session.state = SessionState.DESYNCED
+        else:
+            record.status = TurnStatus.CANCELLED
+            record.error = {
+                "error": "cancelled",
+                "message": "Turn cancelled while in flight.",
+                "http_status": 499,
+                "details": {"session_id": session.session_id, "turn_id": turn_id},
+            }
+        record.updated_at = now
+        session.updated_at = now
+
+    async def _terminate_all_active_turns(self) -> None:
+        tasks = [task for task in self._active_turn_tasks.values() if not task.done()]
+        if not tasks:
+            return
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
     async def _mark_backend_error(self, reason: str) -> None:
         if self._state == ServerState.ERROR:
             return
@@ -763,10 +1128,18 @@ class BlackboxServer:
         turn_id: str,
         error: str,
         message: str,
+        http_status: int | None = None,
+        extra_details: dict[str, Any] | None = None,
     ) -> None:
         turn_record = session.turn_ledger[turn_id]
         turn_record.status = TurnStatus.UNKNOWN
-        turn_record.error = {"error": error, "message": message}
+        details: dict[str, Any] = {"session_id": session.session_id, "turn_id": turn_id}
+        if extra_details:
+            details.update(extra_details)
+        error_payload: dict[str, Any] = {"error": error, "message": message, "details": details}
+        if http_status is not None:
+            error_payload["http_status"] = http_status
+        turn_record.error = error_payload
         turn_record.updated_at = utcnow()
         if session.state != SessionState.ABORTED:
             session.state = SessionState.DESYNCED

--- a/docs/blackbox-server.md
+++ b/docs/blackbox-server.md
@@ -33,7 +33,8 @@ Dressage Proxy → ⚡ SGLang Router
 
 - **Multi-Backend Support** — Pluggable adapter pattern supports `opencode` (code-editing agent via `opencode serve`), `openclaw` (OpenClaw Gateway via `/v1/chat/completions`), `claude_code` (Claude Code headless CLI via Anthropic Messages), and `codex` (Codex CLI via `codex exec --json`). Adding a new backend means implementing a single `BackendAdapter` class with `initialize`, `send_message`, `abort_session`, `health`, and `capabilities` methods; `pause` / `resume` can be overridden when the backend supports them.
 - **In-Process LLM Proxy** — Every BlackboxServer instance runs a lightweight HTTP proxy that intercepts all outgoing LLM calls from the backend agent. This proxy injects session headers (`X-Session-Id`, `X-Instance-Id`, `X-Turn-Id`), routing keys, and partial rollout markers transparently. The agent never knows its calls are being recorded.
-- **Turn Idempotency** — Each turn is identified by a `(turn_id, messages_hash)` tuple. Retrying the same turn with the same messages returns cached responses. Retrying with different messages returns `409 Conflict`. This makes the protocol safe for network retries without duplicating agent work.
+- **Turn Idempotency** — Each turn is identified by a `(turn_id, messages_hash)` tuple. Retrying the same turn with the same messages replays the cached result (committed) or re-attaches to the in-progress execution (queued/inflight) without starting a second agent run; retrying with different messages returns `409 Conflict`. This makes both synchronous calls and asynchronous submit retries safe without duplicating agent work.
+- **Sync + Async turns** — `POST /messages` accepts `mode="sync"` (default, request-bound) or `mode="async"` (submit + `202`, then long-poll `GET /turns/{turn_id}`). At most one turn is active per session; `execute_cmd` is rejected while a turn is active.
 - **Register & Rebind** — Registration is idempotent: calling `POST /v1/rollout/register` with the same parameters while the server is ready is a no-op. If parameters change, the server returns `409 Conflict` while active or desynced sessions still exist; only after no open sessions remain can it tear down and re-initialize with the new configuration.
 - **Health Monitoring** — A background poller periodically checks the backend agent process health. If the agent crashes or becomes unresponsive, the session is marked as `desynced` and the paddock is informed. This prevents silent failures where the agent dies but the rollout keeps waiting.
 - **Single-Session Guarantee** — One server instance manages exactly one agent process and one active session. This ensures clean turn-context attribution: every LLM call within a session is guaranteed to carry the correct session/turn headers. For parallel rollout, deploy one BlackboxServer per sandbox slot.
@@ -165,10 +166,12 @@ The BlackboxServer has a layered internal architecture — FastAPI routes on top
 
  | Method | Path | Purpose | Details |
  | :------- | :----- | :-------- | :-------- |
- | `POST` | `/v1/sessions/{id}/messages` | Send a user turn | Sends messages to agent, waits for completion. Supports turn idempotency via `turn_id`. |
- | `POST` | `/v1/sessions/{id}/execute_cmd` | Execute command | Run a shell command inside the sandbox. Returns stdout/stderr. |
+ | `POST` | `/v1/sessions/{id}/messages` | Submit a user turn | Body `mode` selects behaviour. `mode="sync"` (default) blocks until completion and returns the turn result (fully backward compatible). `mode="async"` accepts the turn and returns `202 Accepted` with `{turn_id, status}`; `turn_id` is **required** in async mode. Turn idempotency keyed on `(turn_id, messages_hash)`. |
+ | `GET` | `/v1/sessions/{id}/turns/{turn_id}` | Poll turn status | Long-poll a submitted turn. Optional `?wait=<seconds>` (clamped to 60) blocks until the turn settles or the wait expires (then returns the current `queued`/`inflight` snapshot — never `504`). Terminal turns return outputs/usage/backend (committed) or `error` (failed/unknown/cancelled). |
+ | `POST` | `/v1/sessions/{id}/turns/{turn_id}/cancel` | Cancel a turn | `queued` turns are cancelled synchronously (`cancelled`); `inflight` turns are cancelled best-effort (`cancel_requested`); terminal turns return their current state idempotently. |
+ | `POST` | `/v1/sessions/{id}/execute_cmd` | Execute command | Run a shell command inside the sandbox. Rejected with `409` while a turn is `queued`/`inflight` (at most one active turn per session). Returns stdout/stderr. |
  | `GET` | `/v1/sessions/{id}` | Get session info | Returns session state, turn history, and metadata. |
- | `POST` | `/v1/sessions/{id}/abort` | Abort session | Cleanly stops the agent session and marks it as aborted. |
+ | `POST` | `/v1/sessions/{id}/abort` | Abort session | Cleanly stops the agent session, cancels any active turn, and marks it as aborted. |
 
 ## 🔄 Data Flow
 
@@ -197,27 +200,42 @@ Register Request (blackbox_type, router, bound_session_id, bound_instance_id, ..
 
 ### 2 Turn Execution
 
-For each turn via `POST /v1/sessions/{id}/messages`:
+A turn is submitted via `POST /v1/sessions/{id}/messages`. Submission is a short
+critical section that accepts the turn and starts a background execution task;
+the actual backend call runs outside the session lock. `mode="sync"` blocks the
+HTTP request until the turn settles (backward compatible); `mode="async"` returns
+`202` immediately and the client polls `GET /v1/sessions/{id}/turns/{turn_id}`.
 
 ```text
-Turn Request (turn_id, messages)
+Turn Submit (turn_id, messages, mode)
         │
-        ├── Check idempotency ledger
-        │   ├── Same (turn_id, messages_hash)? → return cached response
-        │   └── Same turn_id, different messages? → 409 Conflict
+        ├── Admission (under session lock)
+        │   ├── Same (turn_id, messages_hash)?
+        │   │   ├── committed        → idempotent replay of the cached result
+        │   │   ├── queued/inflight  → re-attach to the same execution (no new work)
+        │   │   └── terminal error   → return the existing terminal record
+        │   ├── Same turn_id, different messages? → 409 Conflict
+        │   └── Different turn_id while one is active? → 409 Conflict (active_turn_id)
         │
-        ├── Set proxy context → (session_id, turn_id)
-        │   └── All subsequent LLM calls carry these headers
+        ├── Create TurnRecord(status=queued) + completion event
+        ├── Spawn background task, release lock, return (202 for async)
         │
-        ├── Forward messages to backend agent
-        │   └── Agent runs its logic (code editing, reasoning, etc.)
-        │   └── Agent makes LLM calls → proxy → SGLang
-        │   └── Every token is recorded by Dressage proxy
-        │
-        ├── Store response in idempotency ledger
-        │
-        └── Return agent response to paddock
+        └── Background task (no session lock held)
+            ├── status → inflight
+            ├── Set proxy context → (session_id, turn_id)
+            ├── Forward messages to backend agent (pause-aware, backend_timeout)
+            │   └── Agent makes LLM calls → proxy → SGLang (recorded)
+            ├── Re-acquire lock to commit:
+            │   ├── success           → status committed + response
+            │   ├── timeout           → status unknown (session desynced, 504)
+            │   ├── overflow/steps    → status unknown (413 / 429)
+            │   └── cancel/shutdown   → status cancelled / unknown
+            └── Set completion event (wakes sync waiters and long-polls)
 ```
+
+Turn status lifecycle: `queued → inflight → {committed | failed | cancelled | unknown}`.
+`error.http_status` on a terminal record preserves the original synchronous HTTP
+status so both the sync facade and polling clients surface identical errors.
 
 ### 3 Session Termination
 
@@ -299,7 +317,7 @@ curl -X POST http://127.0.0.1:23456/v1/rollout/register \
     }'
 ```
 
-### Send a Message
+### Send a Message (synchronous)
 
 ```bash
 curl -X POST http://127.0.0.1:23456/v1/sessions/sess-001/messages \
@@ -308,6 +326,25 @@ curl -X POST http://127.0.0.1:23456/v1/sessions/sess-001/messages \
     "turn_id": "turn-001",
     "messages": [{"role": "user", "content": "Fix the bug in main.py"}]
   }'
+```
+
+### Send a Message (asynchronous submit + poll)
+
+```bash
+# Submit (turn_id is required for async) -> 202 Accepted
+curl -X POST http://127.0.0.1:23456/v1/sessions/sess-001/messages \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "turn_id": "turn-001",
+    "mode": "async",
+    "messages": [{"role": "user", "content": "Fix the bug in main.py"}]
+  }'
+
+# Long-poll until the turn settles (wait is clamped to 60s)
+curl "http://127.0.0.1:23456/v1/sessions/sess-001/turns/turn-001?wait=30"
+
+# Cancel an in-flight turn (best effort)
+curl -X POST http://127.0.0.1:23456/v1/sessions/sess-001/turns/turn-001/cancel
 ```
 
 ### Check Status

--- a/docs/paddock.md
+++ b/docs/paddock.md
@@ -94,7 +94,7 @@ BlackboxAgentPaddock
  | `init(traj_id)` | Builds a `SandboxSpec` containing a `blackbox` `SandboxServiceSpec`, calls provider `create()`, resolves the `blackbox` endpoint from `lease.endpoints` or `get_public_url()`, then initializes per-trajectory `SandboxState`. Unless `DRESSAGE_BLACKBOX_SKIP_HEALTHCHECK` is set, the endpoint is health-checked before use. |
  | `register_agent(...)` | Sends `POST /v1/rollout/register` to the BlackboxServer inside the sandbox. The server spawns the backend agent process, starts the in-process LLM proxy, and configures session routing. Idempotent — re-registration with same params is a no-op. |
  | `execute_cmd(...)` | Runs optional shell commands inside the sandbox. Used for per-sample setup: cloning repositories, installing dependencies, creating workspace directories. Commands are specified via `metadata["blackbox_execute_cmds"]`; parsed `before_agent` / `after_agent` results are accumulated in `metadata["execute_cmds"]`. |
- | `call_agent(...)` | Sends the task prompt to the agent via `POST /v1/sessions/{id}/messages`. Blocks until the agent completes or times out. The agent makes LLM calls through BlackboxServer's proxy, which routes through the Dressage proxy for recording. |
+ | `call_agent(...)` | Sends the task prompt to the agent via `POST /v1/sessions/{id}/messages`, reusing one stable `turn_id` across all submit retries (so retries are idempotent). Defaults to `mode="async"` (submit + long-poll `GET /v1/sessions/{id}/turns/{turn_id}?wait=…` until the turn settles); set `DRESSAGE_BLACKBOX_AGENT_CALL_MODE=sync` for the legacy request-bound call. Either way returns a payload matching the legacy synchronous body. The agent makes LLM calls through BlackboxServer's proxy, which routes through the Dressage proxy for recording. |
  | `pause / resume` | Coordinates with the proxy's `GenerationController` for weight updates. `pause` signals all active generation to abort at token boundaries; `resume` re-enables generation after the weight update completes. |
  | `terminate(traj_id)` | Cleanly shuts down the trajectory lease through provider `terminate()`. Guaranteed to run even on errors via try/finally. |
 
@@ -132,6 +132,9 @@ The singleton is created by `create_paddock_from_env()` on first call and cached
  | `DRESSAGE_BLACKBOX_TYPE` / `metadata["blackbox_type"]` | Select the backend agent type: `opencode` (default, code-editing), `openclaw` (OpenClaw gateway). Per-sample metadata can override the environment default. |
  | `DRESSAGE_BLACKBOX_MAX_STEPS` | Positive int forwarded to `backend_options.proxy.max_steps`; `0` disables the backend proxy step limit. |
  | `DRESSAGE_BLACKBOX_COMPACT_THRESHOLD` | Positive int no greater than the context window; controls backend compaction reserve sizing. |
+ | `DRESSAGE_BLACKBOX_AGENT_CALL_MODE` | `async` (default) or `sync`. `async` submits the turn (`202`) and long-polls `GET /turns/{turn_id}` until it settles; `sync` issues a request-bound `/messages` call and returns the result directly. Invalid values fall back to `async`. Both modes reuse one stable `turn_id` across submit retries. |
+ | `DRESSAGE_BLACKBOX_AGENT_POLL_WAIT_SEC` | Per-poll long-poll `wait` seconds for async mode (default `30`, server-clamped to `60`). |
+ | `DRESSAGE_BLACKBOX_AGENT_POLL_TOTAL_TIMEOUT_SEC` | Total client-side polling budget in seconds for async mode (default `0` = unbounded; the server `backend_timeout` remains the backstop). |
 
 > [!WARNING]
 > `blackbox_dispatch` rejects `DRESSAGE_PADDOCK_MODE=whitebox` at startup — use `whitebox_agent` generate function instead. This prevents accidental mode mismatches that would silently produce incorrect trajectories.

--- a/dressage/paddock/blackbox/client.py
+++ b/dressage/paddock/blackbox/client.py
@@ -3,16 +3,33 @@
 from __future__ import annotations
 
 import logging
+import os
+import time
 from typing import Any
+from uuid import uuid4
 
 import httpx
 
 from dressage.paddock.blackbox.common.command import build_execute_cmd_payload
-from dressage.paddock.blackbox.common.http_retry import post_json_with_retry
+from dressage.paddock.blackbox.common.http_retry import (
+    get_json_with_retry,
+    post_json_with_retry,
+)
 from dressage.paddock.blackbox.common.utils import _env_float, _env_int
 from dressage.sandbox.types import SandboxEndpoint
 
 logger = logging.getLogger(__name__)
+
+# Terminal turn states reported by the async turn status endpoint.
+_TURN_COMMITTED = "committed"
+_TURN_ERROR_STATES = frozenset({"failed", "unknown", "cancelled"})
+_TURN_ACTIVE_STATES = frozenset({"queued", "inflight"})
+
+# Client-side /messages submission mode. "async" submits + long-polls (default);
+# "sync" issues a request-bound call and returns the result directly.
+_CALL_MODE_ENV = "DRESSAGE_BLACKBOX_AGENT_CALL_MODE"
+_DEFAULT_CALL_MODE = "async"
+_VALID_CALL_MODES = frozenset({"sync", "async"})
 
 
 class BlackboxServerClient:
@@ -79,15 +96,136 @@ class BlackboxServerClient:
         session_id: str,
         messages: list[dict[str, Any]],
         metadata: dict[str, Any] | None = None,
+        turn_id: str | None = None,
     ) -> dict[str, Any]:
-        response = await self._post_agent_with_retry(
+        """Submit an agent turn asynchronously and poll until it settles.
+
+        A stable ``turn_id`` is generated once (when the caller does not supply
+        one) and reused across the whole submit retry cycle, making the submit
+        POST idempotent: a retried submit re-attaches to the same server-side
+        turn instead of starting a second execution.
+        """
+        if turn_id is None:
+            turn_id = f"turn-{uuid4().hex}"
+        call_mode = self._resolve_call_mode()
+        submit_response = await self._post_agent_with_retry(
             endpoint,
             f"/v1/sessions/{session_id}/messages",
-            json={"messages": messages, "metadata": metadata or {}},
+            json={
+                "turn_id": turn_id,
+                "mode": call_mode,
+                "messages": messages,
+                "metadata": metadata or {},
+            },
             operation="call_agent",
             trajectory_id=trajectory_id,
         )
-        return response.json()
+        if call_mode == "sync":
+            # The server blocks until completion and returns the full result
+            # (or raises the semantic HTTP error), matching the legacy body.
+            return submit_response.json()
+        submit_data = submit_response.json()
+        idempotent_replay = bool(submit_data.get("idempotent_replay", False))
+        return await self._poll_turn(
+            endpoint,
+            trajectory_id=trajectory_id,
+            session_id=session_id,
+            turn_id=turn_id,
+            idempotent_replay=idempotent_replay,
+        )
+
+    @staticmethod
+    def _resolve_call_mode() -> str:
+        raw = os.environ.get(_CALL_MODE_ENV)
+        if raw is None or raw == "":
+            return _DEFAULT_CALL_MODE
+        mode = raw.strip().lower()
+        if mode not in _VALID_CALL_MODES:
+            logger.warning(
+                "invalid %s=%r; falling back to %r",
+                _CALL_MODE_ENV,
+                raw,
+                _DEFAULT_CALL_MODE,
+            )
+            return _DEFAULT_CALL_MODE
+        return mode
+
+    async def _poll_turn(
+        self,
+        endpoint: SandboxEndpoint,
+        *,
+        trajectory_id: str,
+        session_id: str,
+        turn_id: str,
+        idempotent_replay: bool,
+    ) -> dict[str, Any]:
+        poll_wait = _env_float(
+            "DRESSAGE_BLACKBOX_AGENT_POLL_WAIT_SEC", 30.0, min_value=0.0
+        )
+        total_timeout = _env_float(
+            "DRESSAGE_BLACKBOX_AGENT_POLL_TOTAL_TIMEOUT_SEC", 0.0, min_value=0.0
+        )
+        deadline = time.monotonic() + total_timeout if total_timeout > 0 else None
+        url = f"{endpoint.url.rstrip('/')}/v1/sessions/{session_id}/turns/{turn_id}"
+        while True:
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"blackbox turn poll exceeded total timeout for "
+                    f"session_id={session_id} turn_id={turn_id}"
+                )
+            response = await self._get_turn_with_retry(
+                url,
+                params={"wait": poll_wait},
+                operation="poll_turn",
+                trajectory_id=trajectory_id,
+                headers=endpoint.headers,
+            )
+            data = response.json()
+            status = str(data.get("status") or "")
+            if status == _TURN_COMMITTED:
+                return self._committed_call_payload(data, idempotent_replay=idempotent_replay)
+            if status in _TURN_ERROR_STATES:
+                self._raise_turn_error(data, url)
+            # queued / inflight (or unknown transient) -> keep polling.
+
+    @staticmethod
+    def _committed_call_payload(
+        data: dict[str, Any],
+        *,
+        idempotent_replay: bool,
+    ) -> dict[str, Any]:
+        """Assemble a payload matching the legacy synchronous ``/messages`` body."""
+        return {
+            "request_id": data.get("request_id", ""),
+            "session_id": data.get("session_id"),
+            "instance_id": data.get("instance_id"),
+            "turn_id": data.get("turn_id"),
+            "state": data.get("state"),
+            "idempotent_replay": idempotent_replay,
+            "outputs": data.get("outputs") or [],
+            "backend": data.get("backend"),
+            "usage": data.get("usage"),
+        }
+
+    @staticmethod
+    def _raise_turn_error(data: dict[str, Any], url: str) -> None:
+        """Reconstruct the equivalent HTTP error for a terminal-failed turn."""
+        error = data.get("error")
+        if not isinstance(error, dict):
+            error = {}
+        http_status = int(error.get("http_status") or 502)
+        body = {
+            "error": error.get("error", "backend_error"),
+            "message": error.get("message", "blackbox turn failed"),
+            "details": error.get("details") if isinstance(error.get("details"), dict) else {},
+        }
+        request = httpx.Request("GET", url)
+        response = httpx.Response(http_status, json=body, request=request)
+        raise httpx.HTTPStatusError(
+            f"blackbox turn {body['error']} (HTTP {http_status})",
+            request=request,
+            response=response,
+        )
 
     async def execute_cmd(
         self,
@@ -143,15 +281,8 @@ class BlackboxServerClient:
         if self._owns_client:
             await self._client.aclose()
 
-    async def _post_agent_with_retry(
-        self,
-        endpoint: SandboxEndpoint,
-        path: str,
-        *,
-        json: dict[str, Any],
-        operation: str,
-        trajectory_id: str,
-    ) -> httpx.Response:
+    @staticmethod
+    def _retry_config() -> tuple[int, float, float, float]:
         max_attempts = _env_int(
             "DRESSAGE_BLACKBOX_AGENT_REQUEST_MAX_ATTEMPTS",
             _env_int(
@@ -188,6 +319,18 @@ class BlackboxServerClient:
             ),
             min_value=0.0,
         )
+        return max_attempts, initial_delay, max_delay, jitter_fraction
+
+    async def _post_agent_with_retry(
+        self,
+        endpoint: SandboxEndpoint,
+        path: str,
+        *,
+        json: dict[str, Any],
+        operation: str,
+        trajectory_id: str,
+    ) -> httpx.Response:
+        max_attempts, initial_delay, max_delay, jitter_fraction = self._retry_config()
         return await post_json_with_retry(
             self._client,
             f"{endpoint.url.rstrip('/')}{path}",
@@ -201,4 +344,29 @@ class BlackboxServerClient:
             log_prefix="blackbox server",
             logger=logger,
             headers=endpoint.headers,
+        )
+
+    async def _get_turn_with_retry(
+        self,
+        url: str,
+        *,
+        params: dict[str, Any],
+        operation: str,
+        trajectory_id: str,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        max_attempts, initial_delay, max_delay, jitter_fraction = self._retry_config()
+        return await get_json_with_retry(
+            self._client,
+            url,
+            params=params,
+            operation=operation,
+            trajectory_id=trajectory_id,
+            max_attempts=max_attempts,
+            initial_delay=initial_delay,
+            max_delay=max_delay,
+            jitter_fraction=jitter_fraction,
+            log_prefix="blackbox server",
+            logger=logger,
+            headers=headers,
         )

--- a/dressage/paddock/blackbox/common/http_retry.py
+++ b/dressage/paddock/blackbox/common/http_retry.py
@@ -106,6 +106,88 @@ async def post_json_with_retry(
     raise RuntimeError("unreachable blackbox HTTP retry loop exit")
 
 
+async def get_json_with_retry(
+    client: httpx.AsyncClient,
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    retry_statuses: Collection[int] | None = None,
+    operation: str,
+    trajectory_id: str,
+    max_attempts: int,
+    initial_delay: float,
+    max_delay: float,
+    jitter_fraction: float,
+    log_prefix: str,
+    logger: logging.Logger,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    """GET JSON, retrying connect failures and configured HTTP statuses.
+
+    Used for long-poll turn status reads.  Non-retryable HTTP status errors
+    (e.g. 404) are raised directly for the caller to treat as fatal.
+    """
+    retry_status_codes = (
+        DEFAULT_RETRY_HTTP_STATUS_CODES if retry_statuses is None else set(retry_statuses)
+    )
+    delay = min(initial_delay, max_delay) if max_delay > 0 else 0.0
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = await client.get(url, params=params, headers=headers)
+            if response.status_code in retry_status_codes:
+                if attempt >= max_attempts:
+                    logger.warning(
+                        "%s %s for trajectory_id=%s retryable HTTP status "
+                        "exhausted on attempt %d/%d: status=%d body=%r",
+                        log_prefix,
+                        operation,
+                        trajectory_id,
+                        attempt,
+                        max_attempts,
+                        response.status_code,
+                        response_excerpt(response),
+                    )
+                    response.raise_for_status()
+
+                sleep_for = _retry_after_or_jittered_delay(
+                    response,
+                    delay,
+                    jitter_fraction,
+                    max_delay,
+                )
+                if sleep_for > 0:
+                    await asyncio.sleep(sleep_for)
+                delay = _next_delay(delay, initial_delay, max_delay)
+                continue
+
+            response.raise_for_status()
+            return response
+        except (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.PoolTimeout,
+            httpx.ReadTimeout,
+        ) as exc:
+            if attempt >= max_attempts:
+                logger.warning(
+                    "%s %s for trajectory_id=%s connect retry exhausted on "
+                    "attempt %d/%d: %s",
+                    log_prefix,
+                    operation,
+                    trajectory_id,
+                    attempt,
+                    max_attempts,
+                    _exception_summary(exc),
+                )
+                raise
+            sleep_for = _jittered_delay(delay, jitter_fraction)
+            if sleep_for > 0:
+                await asyncio.sleep(sleep_for)
+            delay = _next_delay(delay, initial_delay, max_delay)
+
+    raise RuntimeError("unreachable blackbox HTTP GET retry loop exit")
+
+
 def _next_delay(delay: float, initial_delay: float, max_delay: float) -> float:
     if max_delay > 0:
         return min(delay * 2 if delay > 0 else initial_delay, max_delay)

--- a/dressage/paddock/blackbox/paddock.py
+++ b/dressage/paddock/blackbox/paddock.py
@@ -141,6 +141,7 @@ class BlackboxAgentPaddock(BlackboxPaddock):
         session_id: str,
         messages: list[dict[str, Any]],
         metadata: dict[str, Any] | None = None,
+        turn_id: str | None = None,
     ) -> dict[str, Any]:
         state = self._resolve_state(state)
         return await self._client.call_agent(
@@ -149,6 +150,7 @@ class BlackboxAgentPaddock(BlackboxPaddock):
             session_id=session_id,
             messages=messages,
             metadata=metadata,
+            turn_id=turn_id,
         )
 
     async def execute_cmd(

--- a/dressage/paddock/interface.py
+++ b/dressage/paddock/interface.py
@@ -54,6 +54,7 @@ class BlackboxPaddock(Paddock):
         session_id: str,
         messages: list[dict[str, Any]],
         metadata: dict[str, Any] | None = None,
+        turn_id: str | None = None,
     ) -> dict[str, Any]:
         """Delegate to a blackbox agent and return its response payload."""
 

--- a/tests/blackbox_server/test_async_turns.py
+++ b/tests/blackbox_server/test_async_turns.py
@@ -1,0 +1,560 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from blackbox_server.adapters.base import BackendAdapter
+from blackbox_server.app import create_app
+from blackbox_server.config import BlackboxServerConfig
+from blackbox_server.core.models import (
+    AdapterResponse,
+    BackendCapabilities,
+    Message,
+    RegisterRequest,
+    SessionContext,
+    TraceEvent,
+    TurnContext,
+    TurnRecord,
+    TurnStatus,
+    TurnUsage,
+    utcnow,
+)
+from blackbox_server.core.server import BlackboxServer
+from dressage.paddock.blackbox.client import BlackboxServerClient
+from dressage.sandbox.types import SandboxEndpoint
+
+
+class FakeAdapter(BackendAdapter):
+    def __init__(self) -> None:
+        self.calls = 0
+        self.aborts = 0
+
+    async def initialize(self, binding_context) -> None:  # noqa: D401
+        return None
+
+    async def send_message(
+        self,
+        session_context: SessionContext,
+        turn_context: TurnContext,
+        new_messages: list[Message],
+    ) -> AdapterResponse:
+        self.calls += 1
+        session_context.backend_session_id = session_context.backend_session_id or "oc-session-1"
+        content = new_messages[0].content or ""
+        return AdapterResponse(
+            outputs=[Message(role="assistant", content=f"echo: {content}")],
+            trace_events=[
+                TraceEvent(
+                    turn_id=turn_context.turn_id,
+                    seq=1,
+                    source="fake",
+                    event_type="reasoning",
+                    payload={"text": "fake"},
+                    created_at=utcnow(),
+                )
+            ],
+            usage=TurnUsage(total_tokens=10, input_tokens=4, output_tokens=6, steps=1),
+            backend_session_id=session_context.backend_session_id,
+        )
+
+    async def abort_session(self, session_context: SessionContext) -> bool:
+        self.aborts += 1
+        return True
+
+    async def health(self) -> bool:
+        return True
+
+    async def capabilities(self) -> BackendCapabilities:
+        return BackendCapabilities(
+            chat=True,
+            abort=True,
+            stream=False,
+            multi_message_input=False,
+            system_message=True,
+            history_injection=False,
+        )
+
+    async def shutdown(self) -> None:
+        return None
+
+
+class SlowAdapter(FakeAdapter):
+    def __init__(self, delay: float = 0.2) -> None:
+        super().__init__()
+        self.delay = delay
+
+    async def send_message(
+        self,
+        session_context: SessionContext,
+        turn_context: TurnContext,
+        new_messages: list[Message],
+    ) -> AdapterResponse:
+        self.calls += 1
+        await asyncio.sleep(self.delay)
+        session_context.backend_session_id = session_context.backend_session_id or "oc-session-1"
+        content = new_messages[0].content or ""
+        return AdapterResponse(
+            outputs=[Message(role="assistant", content=f"echo: {content}")],
+            trace_events=[],
+            usage=TurnUsage(total_tokens=1),
+            backend_session_id=session_context.backend_session_id,
+        )
+
+
+def make_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    adapter: BackendAdapter,
+    *,
+    backend_timeout: float = 5.0,
+) -> TestClient:
+    monkeypatch.setattr("blackbox_server.core.server.create_adapter", lambda _: adapter)
+    config = BlackboxServerConfig(
+        runtime_root=str(tmp_path / "runtime"), backend_timeout=backend_timeout
+    )
+    return TestClient(create_app(config))
+
+
+def register_payload() -> dict:
+    return {
+        "blackbox_type": "opencode",
+        "router": "127.0.0.1:30000",
+        "bound_session_id": "sess-001",
+        "bound_instance_id": "inst-001",
+        "backend_options": {"proxy": {}},
+    }
+
+
+def _register(client: TestClient) -> None:
+    resp = client.post("/v1/rollout/register", json=register_payload())
+    assert resp.status_code == 200
+
+
+def test_async_submit_poll_to_committed_matches_sync_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = FakeAdapter()
+    client = make_client(tmp_path, monkeypatch, adapter)
+    with client:
+        _register(client)
+        submit = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-1",
+                "mode": "async",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        assert submit.status_code == 202
+        body = submit.json()
+        assert body["status"] == "queued"
+        assert body["turn_id"] == "turn-1"
+        assert body["idempotent_replay"] is False
+
+        poll = client.get("/v1/sessions/sess-001/turns/turn-1", params={"wait": 5})
+        assert poll.status_code == 200
+        data = poll.json()
+        assert data["status"] == "committed"
+        assert data["state"] == "active"
+        assert data["outputs"][0]["content"] == "echo: hello"
+        assert data["backend"]["backend_session_id"] == "oc-session-1"
+
+        # Same output as the synchronous mode.
+        sync = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={"turn_id": "turn-2", "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert sync.status_code == 200
+        assert sync.json()["outputs"][0]["content"] == "echo: hello"
+
+
+def test_async_submit_requires_turn_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    client = make_client(tmp_path, monkeypatch, FakeAdapter())
+    with client:
+        _register(client)
+        resp = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={"mode": "async", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "request_error"
+    assert "turn_id is required" in resp.json()["message"]
+
+
+def test_async_duplicate_submit_reuses_same_turn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = SlowAdapter(delay=0.2)
+    client = make_client(tmp_path, monkeypatch, adapter)
+    with client:
+        _register(client)
+        payload = {
+            "turn_id": "turn-dup",
+            "mode": "async",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        first = client.post("/v1/sessions/sess-001/messages", json=payload)
+        assert first.status_code == 202
+        second = client.post("/v1/sessions/sess-001/messages", json=payload)
+        assert second.status_code == 202
+        assert second.json()["idempotent_replay"] is True
+        assert second.json()["turn_id"] == "turn-dup"
+
+        poll = client.get("/v1/sessions/sess-001/turns/turn-dup", params={"wait": 5})
+        assert poll.status_code == 200
+        assert poll.json()["status"] == "committed"
+        # The turn executed exactly once despite the duplicate submission.
+        assert adapter.calls == 1
+
+
+def test_async_same_turn_id_different_body_conflicts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    client = make_client(tmp_path, monkeypatch, FakeAdapter())
+    with client:
+        _register(client)
+        first = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-x",
+                "mode": "async",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        assert first.status_code == 202
+        poll = client.get("/v1/sessions/sess-001/turns/turn-x", params={"wait": 5})
+        assert poll.json()["status"] == "committed"
+
+        conflict = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-x",
+                "mode": "async",
+                "messages": [{"role": "user", "content": "different"}],
+            },
+        )
+    assert conflict.status_code == 409
+
+
+def test_async_distinct_turn_while_active_conflicts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = SlowAdapter(delay=0.3)
+    client = make_client(tmp_path, monkeypatch, adapter)
+    with client:
+        _register(client)
+        first = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-active",
+                "mode": "async",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        assert first.status_code == 202
+        conflict = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-second",
+                "mode": "async",
+                "messages": [{"role": "user", "content": "again"}],
+            },
+        )
+        assert conflict.status_code == 409
+        assert conflict.json()["details"]["active_turn_id"] == "turn-active"
+        # Let the active turn finish to drain the background task cleanly.
+        client.get("/v1/sessions/sess-001/turns/turn-active", params={"wait": 5})
+
+
+def test_execute_cmd_conflicts_with_active_turn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = SlowAdapter(delay=0.3)
+    client = make_client(tmp_path, monkeypatch, adapter)
+    with client:
+        _register(client)
+        submit = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-cmd",
+                "mode": "async",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        assert submit.status_code == 202
+        conflict = client.post(
+            "/v1/sessions/sess-001/execute_cmd", json={"cmd": "printf hi"}
+        )
+        assert conflict.status_code == 409
+        assert conflict.json()["details"]["active_turn_id"] == "turn-cmd"
+
+        poll = client.get("/v1/sessions/sess-001/turns/turn-cmd", params={"wait": 5})
+        assert poll.json()["status"] == "committed"
+
+        ok = client.post("/v1/sessions/sess-001/execute_cmd", json={"cmd": "printf hi"})
+        assert ok.status_code == 200
+        assert ok.json()["stdout"] == "hi"
+
+
+def test_long_poll_returns_current_state_then_early_completes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = SlowAdapter(delay=0.5)
+    client = make_client(tmp_path, monkeypatch, adapter)
+    with client:
+        _register(client)
+        submit = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-poll",
+                "mode": "async",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        assert submit.status_code == 202
+
+        short = client.get("/v1/sessions/sess-001/turns/turn-poll", params={"wait": 0.05})
+        assert short.status_code == 200
+        assert short.json()["status"] in {"queued", "inflight"}
+
+        done = client.get("/v1/sessions/sess-001/turns/turn-poll", params={"wait": 5})
+        assert done.status_code == 200
+        assert done.json()["status"] == "committed"
+
+
+def test_get_unknown_turn_returns_404(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    client = make_client(tmp_path, monkeypatch, FakeAdapter())
+    with client:
+        _register(client)
+        resp = client.get("/v1/sessions/sess-001/turns/turn-missing")
+    assert resp.status_code == 404
+
+
+def test_cancel_inflight_turn_then_terminal_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = SlowAdapter(delay=1.0)
+    client = make_client(tmp_path, monkeypatch, adapter)
+    with client:
+        _register(client)
+        submit = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-cancel",
+                "mode": "async",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        assert submit.status_code == 202
+
+        cancel = client.post("/v1/sessions/sess-001/turns/turn-cancel/cancel")
+        assert cancel.status_code == 200
+        assert cancel.json()["status"] == "cancel_requested"
+
+        poll = client.get("/v1/sessions/sess-001/turns/turn-cancel", params={"wait": 5})
+        assert poll.json()["status"] == "cancelled"
+
+        # Cancelling a terminal turn is idempotent.
+        again = client.post("/v1/sessions/sess-001/turns/turn-cancel/cancel")
+        assert again.status_code == 200
+        assert again.json()["status"] == "cancelled"
+
+
+def test_backend_timeout_marks_turn_unknown_and_session_desynced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = SlowAdapter(delay=0.3)
+    client = make_client(tmp_path, monkeypatch, adapter, backend_timeout=0.01)
+    with client:
+        _register(client)
+        submit = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-timeout",
+                "mode": "async",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        assert submit.status_code == 202
+
+        poll = client.get("/v1/sessions/sess-001/turns/turn-timeout", params={"wait": 5})
+        assert poll.status_code == 200
+        data = poll.json()
+        assert data["status"] == "unknown"
+        assert data["error"]["error"] == "backend_timeout"
+        assert data["error"]["http_status"] == 504
+
+        session = client.get("/v1/sessions/sess-001", params={"include_turns": "true"})
+        assert session.json()["state"] == "desynced"
+
+
+def test_cancel_queued_turn_is_synchronously_cancelled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    asyncio.run(_run_cancel_queued_turn(tmp_path, monkeypatch))
+
+
+async def _run_cancel_queued_turn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = FakeAdapter()
+    monkeypatch.setattr("blackbox_server.core.server.create_adapter", lambda _: adapter)
+    config = BlackboxServerConfig(
+        runtime_root=str(tmp_path / "runtime"),
+        backend_timeout=5.0,
+        runtime_health_check_interval=999.0,
+    )
+    server = BlackboxServer(config)
+    await server.register(
+        RegisterRequest(
+            blackbox_type="opencode",
+            router="127.0.0.1:30000",
+            bound_session_id="sess-001",
+            bound_instance_id="inst-001",
+            backend_options={"proxy": {}},
+        )
+    )
+    try:
+        session = await server._session_store.get("sess-001")
+        now = utcnow()
+        session.turn_ledger["turn-q"] = TurnRecord(
+            turn_id="turn-q",
+            request_fingerprint="fp",
+            status=TurnStatus.QUEUED,
+            request_messages=[Message(role="user", content="hi")],
+            created_at=now,
+            updated_at=now,
+        )
+        server._turn_events[("sess-001", "turn-q")] = asyncio.Event()
+
+        response = await server.cancel_turn("sess-001", "turn-q")
+        assert response.status == "cancelled"
+        assert session.turn_ledger["turn-q"].status == TurnStatus.CANCELLED
+        assert server._turn_events[("sess-001", "turn-q")].is_set()
+    finally:
+        await server.graceful_shutdown()
+
+
+def test_client_call_agent_reuses_turn_id_across_retry(monkeypatch: pytest.MonkeyPatch):
+    asyncio.run(_run_client_call_agent_reuses_turn_id(monkeypatch))
+
+
+async def _run_client_call_agent_reuses_turn_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DRESSAGE_BLACKBOX_AGENT_REQUEST_INITIAL_DELAY_SEC", "0")
+    monkeypatch.setenv("DRESSAGE_BLACKBOX_AGENT_REQUEST_MAX_DELAY_SEC", "0")
+    monkeypatch.setenv("DRESSAGE_BLACKBOX_AGENT_POLL_WAIT_SEC", "0")
+
+    submit_turn_ids: list[str] = []
+    counters = {"post": 0, "get": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/messages"):
+            body = json.loads(request.content.decode())
+            assert body["mode"] == "async"
+            submit_turn_ids.append(body["turn_id"])
+            counters["post"] += 1
+            if counters["post"] == 1:
+                raise httpx.ConnectError("transient connect failure")
+            return httpx.Response(
+                202,
+                json={
+                    "session_id": "sess-1",
+                    "turn_id": body["turn_id"],
+                    "status": "queued",
+                    "idempotent_replay": counters["post"] > 1,
+                },
+            )
+        if "/turns/" in request.url.path:
+            counters["get"] += 1
+            turn_id = request.url.path.rsplit("/", 1)[-1]
+            if counters["get"] == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "session_id": "sess-1",
+                        "turn_id": turn_id,
+                        "status": "inflight",
+                        "state": "active",
+                    },
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "session_id": "sess-1",
+                    "turn_id": turn_id,
+                    "status": "committed",
+                    "state": "active",
+                    "outputs": [{"role": "assistant", "content": "done"}],
+                    "backend": {"type": "opencode", "backend_session_id": "oc-1"},
+                    "usage": {"total_tokens": 3},
+                },
+            )
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = BlackboxServerClient(client=http_client)
+    endpoint = SandboxEndpoint(url="http://sandbox.test", headers={})
+    payload = await client.call_agent(
+        endpoint,
+        trajectory_id="sess-1",
+        session_id="sess-1",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert payload["outputs"][0]["content"] == "done"
+    assert counters["post"] == 2  # submit retried once
+    assert counters["get"] == 2  # polled inflight then committed
+    assert len(set(submit_turn_ids)) == 1  # same turn_id reused across retry
+    await http_client.aclose()
+
+
+def test_client_call_agent_sync_mode_via_env(monkeypatch: pytest.MonkeyPatch):
+    asyncio.run(_run_client_call_agent_sync_mode(monkeypatch))
+
+
+async def _run_client_call_agent_sync_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DRESSAGE_BLACKBOX_AGENT_CALL_MODE", "sync")
+
+    counters = {"post": 0, "get": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/messages"):
+            body = json.loads(request.content.decode())
+            assert body["mode"] == "sync"
+            assert body["turn_id"].startswith("turn-")
+            counters["post"] += 1
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "req-1",
+                    "session_id": "sess-1",
+                    "turn_id": body["turn_id"],
+                    "state": "active",
+                    "idempotent_replay": False,
+                    "outputs": [{"role": "assistant", "content": "done"}],
+                    "backend": {"type": "opencode", "backend_session_id": "oc-1"},
+                    "usage": {"total_tokens": 3},
+                },
+            )
+        if "/turns/" in request.url.path:
+            counters["get"] += 1
+            raise AssertionError("sync mode must not poll the turns endpoint")
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = BlackboxServerClient(client=http_client)
+    endpoint = SandboxEndpoint(url="http://sandbox.test", headers={})
+    payload = await client.call_agent(
+        endpoint,
+        trajectory_id="sess-1",
+        session_id="sess-1",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert payload["outputs"][0]["content"] == "done"
+    assert counters["post"] == 1
+    assert counters["get"] == 0  # no polling in sync mode
+    await http_client.aclose()

--- a/tests/blackbox_server/test_server.py
+++ b/tests/blackbox_server/test_server.py
@@ -126,6 +126,16 @@ class MaxStepsExceededAdapter(FakeAdapter):
         )
 
 
+class UnexpectedErrorAdapter(FakeAdapter):
+    async def send_message(
+        self,
+        session_context: SessionContext,
+        turn_context: TurnContext,
+        new_messages: list[Message],
+    ) -> AdapterResponse:
+        raise RuntimeError("boom: unexpected backend failure")
+
+
 class SlowAdapter(FakeAdapter):
     async def send_message(
         self,
@@ -705,6 +715,55 @@ def test_max_steps_exceeded_returns_429_without_marking_server_error(
     assert turn["error"]["error"] == "max_steps_exceeded"
     assert execute_response.status_code == 200
     assert execute_response.json()["stdout"] == "harvested"
+
+
+def test_unexpected_error_returns_500_and_desyncs_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    prompt_file: Path,
+):
+    """An unexpected exception must settle the turn instead of leaving it INFLIGHT."""
+
+    client = make_client(tmp_path, monkeypatch, UnexpectedErrorAdapter())
+
+    with client:
+        register_response = client.post("/v1/rollout/register", json=register_payload(prompt_file))
+        assert register_response.status_code == 200
+
+        response = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-boom",
+                "messages": [{"role": "user", "content": "trigger"}],
+            },
+        )
+        status_response = client.get("/v1/status")
+        session_response = client.get(
+            "/v1/sessions/sess-001",
+            params={"include_turns": "true"},
+        )
+        next_message_response = client.post(
+            "/v1/sessions/sess-001/messages",
+            json={
+                "turn_id": "turn-after-boom",
+                "messages": [{"role": "user", "content": "continue"}],
+            },
+        )
+
+    # The synchronous facade must return promptly with a 500 rather than hang.
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error"] == "internal_error"
+    assert "Unexpected backend failure" in body["message"]
+    # Adapter health still passes, so the server itself is not marked as errored.
+    assert status_response.json()["status"] == "ready"
+    # The turn is settled as UNKNOWN and the session is desynced (not stuck INFLIGHT).
+    assert session_response.json()["state"] == "desynced"
+    turn = session_response.json()["turn_ledger"]["turn-boom"]
+    assert turn["status"] == "unknown"
+    assert turn["error"]["error"] == "internal_error"
+    assert next_message_response.status_code == 409
+    assert "desynced" in next_message_response.json()["message"]
 
 
 def test_execute_cmd_success_and_default_timeout(

--- a/tests/test_new_paddock_layers.py
+++ b/tests/test_new_paddock_layers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 import httpx
@@ -77,7 +78,36 @@ async def _run_blackbox_agent_paddock_uses_provider_and_blackbox_client():
             assert "runtime_root" not in body
             return httpx.Response(200, json={"ok": True})
         if request.url.path == "/v1/sessions/traj-1/messages":
-            return httpx.Response(200, json={"response": "done"})
+            # Async submit acknowledgement (202) with the caller-supplied turn_id.
+            body = json.loads(request.content.decode())
+            assert body["mode"] == "async"
+            return httpx.Response(
+                202,
+                json={
+                    "request_id": "req-1",
+                    "session_id": "traj-1",
+                    "turn_id": body["turn_id"],
+                    "status": "queued",
+                    "idempotent_replay": False,
+                },
+            )
+        if request.url.path.startswith("/v1/sessions/traj-1/turns/"):
+            turn_id = request.url.path.rsplit("/", 1)[-1]
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "req-1",
+                    "session_id": "traj-1",
+                    "turn_id": turn_id,
+                    "status": "committed",
+                    "state": "active",
+                    "outputs": [{"role": "assistant", "content": "done"}],
+                    "backend": {"type": "opencode", "backend_session_id": "oc-1"},
+                    "usage": {"total_tokens": 1},
+                    "created_at": "2026-05-29T00:00:00Z",
+                    "updated_at": "2026-05-29T00:00:01Z",
+                },
+            )
         if request.url.path == "/v1/sessions/traj-1/execute_cmd":
             return httpx.Response(200, json={"returncode": 0, "stdout": "Python\n"})
         raise AssertionError(f"unexpected path {request.url.path}")
@@ -101,7 +131,8 @@ async def _run_blackbox_agent_paddock_uses_provider_and_blackbox_client():
     assert provider.created[0].metadata == {"paddock_mode": "blackbox"}
 
     assert await paddock.register_agent(state, instance_id="inst", session_id="traj-1") == {"ok": True}
-    assert (await paddock.call_agent(state, session_id="traj-1", messages=[]))["response"] == "done"
+    call_payload = await paddock.call_agent(state, session_id="traj-1", messages=[])
+    assert call_payload["outputs"][0]["content"] == "done"
     assert (await paddock.execute_cmd(state, session_id="traj-1", cmd="python -V"))["returncode"] == 0
 
     await client.aclose()


### PR DESCRIPTION
## Summary

Convert BlackboxServer's `POST /v1/sessions/{id}/messages` (the `call_agent` path) from request-bound synchronous execution to a submit + long-poll async model (issue #14). The default external behavior stays fully backward compatible: requests without a `mode` field still follow synchronous semantics with identical HTTP status/error codes, while new async submission, turn-status polling, and cancellation capabilities are added. The core fix is having the client reuse one stable `turn_id` across its entire retry cycle, making submit retries inherently idempotent so agent execution is never duplicated. No SSE, no persistent storage, and no new external dependencies are introduced.

## Design

- **State machine**: `TurnStatus` is extended to `queued → inflight → {committed | failed | cancelled | unknown}`; `MessageRequest` gains `mode: sync|async` (default `sync`).
- **Server**: `send_message` is split into `submit_turn` (short admission critical section — idempotency check, one-active-turn-per-session admission) and `_run_turn` (background execution off the session lock, preserving pause-aware timeout, re-acquiring the lock to commit results). `send_message` becomes a sync facade that waits on the turn completion event and reconstructs the exact original synchronous HTTP error from `TurnRecord.error.http_status`. Adds `get_turn` (long-poll, `wait` clamped to 60s, returns the current state on expiry rather than 504) and `cancel_turn`; `execute_cmd` is 409-gated against active turns; `abort_session`/`graceful_shutdown` now cancel background turn tasks (shutdown → UNKNOWN + desync, mirroring the timeout path).
- **API**: `/messages` branches on `mode` (sync = 200 / async = 202); adds `GET /turns/{turn_id}?wait=` and `POST /turns/{turn_id}/cancel`.
- **Client**: `call_agent` generates a stable `turn_id` before the first submit and reuses it across all retries; in `async` mode it polls to a terminal state and re-raises terminal errors as an equivalent `httpx.HTTPStatusError` so `failures.py` classification is unchanged. Adds `DRESSAGE_BLACKBOX_AGENT_CALL_MODE` (`async` default / `sync`) plus `POLL_WAIT_SEC` / `POLL_TOTAL_TIMEOUT_SEC` tunables.

## Validation

- Existing `tests/blackbox_server/` and `tests/test_blackbox_dispatch.py` pass **unmodified** (the sync default guarantees backward compatibility); only `test_new_paddock_layers.py` received a minimal mock adjustment because it directly asserted the old synchronous round trip.
- Added `tests/blackbox_server/test_async_turns.py` (13 cases): async submit → poll committed matches sync output, async missing turn_id → 400, duplicate submit reuses a single execution, same/different-fingerprint and distinct-turn_id conflicts, execute_cmd gating, long-poll expiry/early-completion, backend timeout → UNKNOWN + 504 + desynced, queued/inflight/terminal cancellation, client turn_id reuse across retries, and `CALL_MODE=sync` skips polling.
- Acceptance command `pytest tests/blackbox_server/ tests/test_blackbox_dispatch.py -q` is green (the only failure is a pre-existing environmental issue in `test_command.py`, which depends on a `python` binary and is unrelated to this change — confirmed reproducible on a clean checkout).