### PR TITLE
feat(paddock): add write_files to blackbox paddock interface

### DIFF
--- a/dressage/paddock/interface.py
+++ b/dressage/paddock/interface.py
@@ -70,6 +70,23 @@ class BlackboxPaddock(Paddock):
         """Execute a shell command in a blackbox session."""
 
     @abc.abstractmethod
+    async def write_files(
+        self,
+        state: Any,
+        *,
+        files: list[dict[str, Any]],
+        dist_path: str = "/data",
+    ) -> dict[str, Any]:
+        """Upload files into the sandbox service.
+
+        Intended for provider-side file delivery that bypasses the agent
+        protocol, e.g. installing an agent harness at runtime or staging
+        reward/grader scripts before scoring.  Each entry describes one file
+        (source + destination); ``dist_path`` is the default prefix applied to
+        relative destination paths.
+        """
+
+    @abc.abstractmethod
     async def pause(
         self,
         traj_id: str | None = None,

--- a/dressage/recipes/dressage_claw/dispatch.py
+++ b/dressage/recipes/dressage_claw/dispatch.py
@@ -193,11 +193,7 @@ async def _write_stage_files(paddock: Any, state: Any, metadata: dict[str, Any],
     files = metadata.get(f"{stage}_files")
     if not files:
         return
-    write_files = getattr(paddock, "write_files", None)
-    if write_files is None:
-        logger.warning("paddock has no write_files; skipping %s_files (%d files)", stage, len(files))
-        return
-    await maybe_await(write_files(state, files=files))
+    await maybe_await(paddock.write_files(state, files=files))
 
 
 # ---------------------------------------------------------------------------

--- a/dressage/sandbox/local/bwrap/provider.py
+++ b/dressage/sandbox/local/bwrap/provider.py
@@ -204,6 +204,29 @@ class LocalBwrapSandboxProvider:
             append=append,
         )
 
+    async def write_files(
+        self,
+        lease: SandboxLease,
+        *,
+        files: list[dict[str, Any]],
+        dist_path: str = "/data",
+    ) -> dict[str, Any]:
+        """No-op batch upload for the local bwrap provider.
+
+        bwrap shares the sandbox filesystem with the host through bind mounts
+        (``/workspace`` maps to the slot work_dir), so harness/reward files are
+        already reachable locally and never need to be transferred.  This exists
+        only to satisfy the provider surface used by blackbox file staging; on
+        remote providers (e.g. E2B) this is where real uploads happen.
+        """
+        del lease, dist_path
+        return {
+            "files_written": 0,
+            "skipped": True,
+            "reason": "shared_fs",
+            "requested": len(files),
+        }
+
     def _connect_manager(self, *, ray_address: str | None = None) -> Any:
         try:
             import ray


### PR DESCRIPTION
- Promote write_files to a first-class abstract method on BlackboxPaddock
- Add no-op write_files for the local bwrap provider (shared bind-mount filesystem needs no upload)
- Simplify dressage-claw dispatch to call write_files directly instead of getattr