### PR TITLE
fix(paddock): prevent drain_lifecycle_tasks from busy-spinning the event loop

### DIFF
--- a/dressage/paddock/lifecycle.py
+++ b/dressage/paddock/lifecycle.py
@@ -191,9 +191,21 @@ def schedule_terminate_paddock(
 async def drain_lifecycle_tasks() -> None:
     """Wait for all tracked cleanup, including tasks spawned while draining."""
     loop = asyncio.get_running_loop()
-    while tracked := _LIFECYCLE_TASKS.get(loop):
+    while True:
+        tracked = _LIFECYCLE_TASKS.get(loop)
+        if not tracked:
+            break
         tasks = tuple(tracked)
         await asyncio.gather(*tasks, return_exceptions=True)
+        # Finished tasks are normally removed by their done-callbacks, but those
+        # run on a later loop iteration. Awaiting an all-completed gather may
+        # return without yielding (Python 3.12), so proactively drop finished
+        # tasks here; otherwise this loop spins and starves the event loop.
+        for task in tasks:
+            if task.done():
+                tracked.discard(task)
+        if not tracked:
+            _LIFECYCLE_TASKS.pop(loop, None)
 
 
 async def drain_terminate_tasks() -> None:

--- a/tests/test_rollout_helper_modules.py
+++ b/tests/test_rollout_helper_modules.py
@@ -162,6 +162,58 @@ async def _run_lifecycle_terminate_timeout_can_be_drained(monkeypatch):
     ]
 
 
+def test_drain_lifecycle_tasks_does_not_spin_on_completed_tasks():
+    asyncio.run(_run_drain_lifecycle_tasks_does_not_spin_on_completed_tasks())
+
+
+async def _run_drain_lifecycle_tasks_does_not_spin_on_completed_tasks():
+    """Regression: draining all-completed tasks must not busy-spin the loop.
+
+    Historically ``drain_lifecycle_tasks`` relied on each task's done-callback
+    to remove it from ``_LIFECYCLE_TASKS``. Those callbacks only run on a later
+    loop iteration, and awaiting an all-completed ``gather`` can return without
+    yielding (Python 3.12). The result was an infinite tight loop that starved
+    the event loop. Here we seed the registry with already-finished tasks that
+    are NOT auto-removed, so draining must proactively discard them and return
+    promptly instead of hanging.
+    """
+    loop = asyncio.get_running_loop()
+
+    async def _noop() -> None:
+        return None
+
+    finished = [asyncio.ensure_future(_noop()) for _ in range(3)]
+    await asyncio.gather(*finished)
+    assert all(task.done() for task in finished)
+
+    # Seed the registry directly (bypassing add_done_callback) so nothing else
+    # removes the completed tasks: only a correct drain loop can clear them.
+    lifecycle._LIFECYCLE_TASKS[loop] = set(finished)
+    try:
+        drain = asyncio.ensure_future(lifecycle.drain_lifecycle_tasks())
+        # Watchdog proves the loop keeps iterating: if drain busy-spins and
+        # starves the loop, neither this sleep nor drain resolves and the test
+        # hangs (caught by the outer timeout guard). When drain yields properly
+        # it finishes first, well before the watchdog.
+        watchdog = asyncio.ensure_future(asyncio.sleep(5))
+        done, _pending = await asyncio.wait(
+            {drain, watchdog},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        assert drain in done, "drain_lifecycle_tasks starved the event loop"
+        watchdog.cancel()
+        try:
+            await watchdog
+        except asyncio.CancelledError:
+            pass
+        await drain  # surface any exception raised inside drain
+    finally:
+        lifecycle._LIFECYCLE_TASKS.pop(loop, None)
+
+    assert loop not in lifecycle._LIFECYCLE_TASKS
+    assert lifecycle.pending_lifecycle_task_count() == 0
+
+
 def test_generate_runtime_paddock_env_args_only_uses_supported_keys():
     env_args = generate_runtime.paddock_env_args_from_metadata(
         {


### PR DESCRIPTION
### problem
tests/test_prewarm_provider_integration.py::test_e2b_cleanup_returns_before_create_then_kills_sandbox hangs forever at 100% CPU, blocking the whole suite (since testpaths = ["tests"]). Reproduces on Python 3.12.11, independent of the pytest-asyncio version.

### Root cause
In drain_lifecycle_tasks(), when all tracked tasks are already done, await asyncio.gather(...) returns without yielding on Python 3.12. The done-callbacks that remove finished tasks from _LIFECYCLE_TASKS only run on the next loop iteration — which never happens. So the while keeps seeing a non-empty set and spins forever, starving the loop.

### Fix
Proactively discard finished tasks inside the drain loop instead of relying on done-callback timing. Behavior is unchanged (still drains tasks spawned during draining; drain_terminate_tasks alias untouched).

### Tests
Added a regression test that seeds the registry with already-completed tasks and asserts draining returns promptly. All 42 related async tests pass; the previously hanging case now passes in ~4s. Reverting the fix makes the new test hang, confirming it catches the bug.

### Scope
Only dressage/paddock/lifecycle.py + tests/test_rollout_helper_modules.py. 