### PR TITLE
feat(prewarm): add sandbox prewarm hit-rate observability to wandb

### DIFF
--- a/dressage/rollout/fully_async_rollout.py
+++ b/dressage/rollout/fully_async_rollout.py
@@ -39,6 +39,7 @@ except ImportError:
 from dressage.paddock.lifecycle import drain_lifecycle_tasks
 from dressage.rollout.multi_segment import (
     compute_multi_segment_metrics,
+    compute_prewarm_metrics,
     mark_aborted_no_grad,
 )
 from dressage.rollout.staleness import (
@@ -608,9 +609,9 @@ def generate_rollout_fully_async(
                 rollout_id,
             )
             stop_global_worker()
-    metrics: dict[str, Any] = compute_multi_segment_metrics(
-        [sample for group in data for sample in group]
-    )
+    flat = [sample for group in data for sample in group]
+    metrics: dict[str, Any] = compute_multi_segment_metrics(flat)
+    metrics.update(compute_prewarm_metrics(flat))
     metrics.update(staleness_metrics)
     if RolloutFnTrainOutput is None:
         return data

--- a/dressage/rollout/generate/blackbox_dispatch.py
+++ b/dressage/rollout/generate/blackbox_dispatch.py
@@ -116,6 +116,7 @@ async def generate(
             blackbox_type=blackbox_type,
         )
         proxy_client = get_proxy_client()
+        prewarm_requested = bool(metadata.get("prewarm_requested"))
         prewarm_t0 = time.monotonic()
         handle = await claim_prewarm(session_id)
         prewarm_wait = time.monotonic() - prewarm_t0
@@ -124,6 +125,11 @@ async def generate(
             state = handle.state
             env_args = handle.env_args
             initialized = True
+            # Only trajectories that requested a prewarm contribute to the
+            # prewarm hit-rate metrics (see compute_prewarm_metrics).
+            if prewarm_requested:
+                metadata["prewarm_hit"] = 1
+                metadata["prewarm_wait_seconds"] = prewarm_wait
             logger.debug(
                 "claimed prewarmed sandbox for session_id=%s group_id=%d: "
                 "wait=%.2fs",
@@ -132,6 +138,8 @@ async def generate(
                 prewarm_wait,
             )
         else:
+            if prewarm_requested:
+                metadata["prewarm_hit"] = 0
             previous_session_id = session_id
             sample.session_id = None
             session_id = ensure_blackbox_session_id(sample)

--- a/dressage/rollout/log_rollout.py
+++ b/dressage/rollout/log_rollout.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from dressage.training.log_helpers import compute_trajectory_mean_raw_reward
 
-_STALENESS_WANDB_METRICS_DEFINED = False
+_ROLLOUT_WANDB_METRICS_DEFINED = False
 
 
 def _metric_component(value: str) -> str:
@@ -27,8 +27,8 @@ def _metric_component(value: str) -> str:
 
 
 def _define_staleness_wandb_metrics(args: Any) -> None:
-    global _STALENESS_WANDB_METRICS_DEFINED
-    if _STALENESS_WANDB_METRICS_DEFINED or not getattr(args, "use_wandb", False):
+    global _ROLLOUT_WANDB_METRICS_DEFINED
+    if _ROLLOUT_WANDB_METRICS_DEFINED or not getattr(args, "use_wandb", False):
         return
 
     import wandb
@@ -36,7 +36,10 @@ def _define_staleness_wandb_metrics(args: Any) -> None:
     if wandb.run is None:
         return
     wandb.define_metric("staleness/*", step_metric="rollout/step")
-    _STALENESS_WANDB_METRICS_DEFINED = True
+    # Sandbox-prewarm observability (hit rate / wait time), see
+    # dressage.rollout.multi_segment.compute_prewarm_metrics.
+    wandb.define_metric("prewarm/*", step_metric="rollout/step")
+    _ROLLOUT_WANDB_METRICS_DEFINED = True
 
 
 def _sample_has_trainable_loss(sample: Any) -> bool:

--- a/dressage/rollout/multi_segment.py
+++ b/dressage/rollout/multi_segment.py
@@ -247,3 +247,56 @@ def compute_multi_segment_metrics(samples: list[Any]) -> dict[str, float]:
         })
 
     return metrics
+
+
+def compute_prewarm_metrics(samples: list[Any]) -> dict[str, float]:
+    """Sandbox-prewarm hit-rate stats keyed under ``prewarm/`` for wandb.
+
+    Only trajectories that actually requested a prewarm (stamped by the
+    scheduler via ``metadata['prewarm_requested']``) are counted, so
+    rollout modes that never prewarm (e.g. sync) emit no prewarm metrics at
+    all instead of a misleading 0% hit rate.
+
+    Buckets samples by trajectory (``metadata['parent_traj_id']``, falling
+    back to ``_metric_trajectory_id``) so a multi-segment trajectory counts
+    once. ``remove_sample=True`` (aborted/no-grad) samples are intentionally
+    NOT excluded here: a prewarm *hit* reflects sandbox reuse and is
+    independent of whether the rollout later succeeded.
+
+    Called from the slime-facing rollout entrypoints (sync + fully_async +
+    partial_async) so the metrics ride through ``RolloutFnTrainOutput.metrics``.
+    """
+    hits_by_traj: dict[str, bool] = {}
+    waits: list[float] = []
+    for s in samples:
+        meta = getattr(s, "metadata", None) or {}
+        if not meta.get("prewarm_requested"):
+            continue
+        traj_id = meta.get("parent_traj_id") or _metric_trajectory_id(s)
+        if traj_id is None or traj_id in hits_by_traj:
+            continue
+        hit = int(meta.get("prewarm_hit", 0)) == 1
+        hits_by_traj[traj_id] = hit
+        if hit:
+            wait = meta.get("prewarm_wait_seconds")
+            if wait is not None:
+                waits.append(float(wait))
+
+    if not hits_by_traj:
+        return {}
+
+    num_requested = len(hits_by_traj)
+    num_hits = sum(1 for hit in hits_by_traj.values() if hit)
+    metrics: dict[str, float] = {
+        "prewarm/num_requested": float(num_requested),
+        "prewarm/num_hits": float(num_hits),
+        "prewarm/num_misses": float(num_requested - num_hits),
+        "prewarm/hit_rate": num_hits / num_requested,
+    }
+    if waits:
+        metrics.update({
+            "prewarm/wait_seconds_mean": sum(waits) / len(waits),
+            "prewarm/wait_seconds_max": float(max(waits)),
+            "prewarm/wait_seconds_min": float(min(waits)),
+        })
+    return metrics

--- a/dressage/rollout/partial_async_rollout.py
+++ b/dressage/rollout/partial_async_rollout.py
@@ -585,11 +585,14 @@ async def generate_rollout_partial_async_impl(
             "Set DRESSAGE_ALLOW_EMPTY_TRAIN_BATCH=1 to keep the previous behavior."
         )
 
-    from dressage.rollout.multi_segment import compute_multi_segment_metrics
-
-    metrics: dict[str, Any] = compute_multi_segment_metrics(
-        [sample for group in data_groups for sample in group]
+    from dressage.rollout.multi_segment import (
+        compute_multi_segment_metrics,
+        compute_prewarm_metrics,
     )
+
+    flat = [sample for group in data_groups for sample in group]
+    metrics: dict[str, Any] = compute_multi_segment_metrics(flat)
+    metrics.update(compute_prewarm_metrics(flat))
     metrics.update(staleness_filter.metrics_for_groups(data_groups))
     metrics.update({
         "dressage/partial_rollout_target_groups": target_groups,

--- a/dressage/rollout/prewarm/scheduler.py
+++ b/dressage/rollout/prewarm/scheduler.py
@@ -124,6 +124,11 @@ class PrewarmScheduler:
                 paddock=paddock,
                 env_args=env_args,
             ) is not None:
+                # Mark the sample so dispatch can attribute a prewarm hit/miss
+                # only to trajectories that actually requested a prewarm. This
+                # keeps prewarm hit-rate metrics clean of non-prewarmed rollout
+                # modes (e.g. sync) where no prewarm is ever started.
+                metadata["prewarm_requested"] = True
                 started += 1
         return started
 

--- a/dressage/rollout/sync_rollout.py
+++ b/dressage/rollout/sync_rollout.py
@@ -39,7 +39,10 @@ except ImportError:
     def run(coro):  # type: ignore[no-redef]
         return asyncio.run(coro)
 
-from dressage.rollout.multi_segment import compute_multi_segment_metrics
+from dressage.rollout.multi_segment import (
+    compute_multi_segment_metrics,
+    compute_prewarm_metrics,
+)
 
 
 def _max_retries() -> int:
@@ -158,9 +161,9 @@ def generate_rollout_sync(
     if evaluation:
         raise ValueError("Dressage sync rollout does not support evaluation mode")
     data = run(_run_sync_rollout(args, rollout_id, data_buffer))
-    metrics: dict[str, Any] = compute_multi_segment_metrics(
-        [sample for group in data for sample in group]
-    )
+    flat = [sample for group in data for sample in group]
+    metrics: dict[str, Any] = compute_multi_segment_metrics(flat)
+    metrics.update(compute_prewarm_metrics(flat))
     if RolloutFnTrainOutput is None:
         return data
     return RolloutFnTrainOutput(samples=data, metrics=metrics)

--- a/tests/test_log_rollout_data.py
+++ b/tests/test_log_rollout_data.py
@@ -89,13 +89,16 @@ def test_rollout_hook_defines_staleness_wandb_step_metric(monkeypatch):
             calls.append((name, kwargs))
 
     monkeypatch.setitem(sys.modules, "wandb", FakeWandb)
-    monkeypatch.setattr(log_rollout_module, "_STALENESS_WANDB_METRICS_DEFINED", False)
+    monkeypatch.setattr(log_rollout_module, "_ROLLOUT_WANDB_METRICS_DEFINED", False)
 
     args = SimpleNamespace(use_wandb=True)
     assert log_rollout_data(0, args, [], {}, 0.0) is False
     assert log_rollout_data(1, args, [], {}, 0.0) is False
 
-    assert calls == [("staleness/*", {"step_metric": "rollout/step"})]
+    assert calls == [
+        ("staleness/*", {"step_metric": "rollout/step"}),
+        ("prewarm/*", {"step_metric": "rollout/step"}),
+    ]
 
 
 def test_single_segment_trajectories():

--- a/tests/test_multi_segment.py
+++ b/tests/test_multi_segment.py
@@ -18,6 +18,7 @@ import pytest
 
 from dressage.rollout.multi_segment import (
     compute_multi_segment_metrics,
+    compute_prewarm_metrics,
     expand_segments_to_samples,
     mark_aborted_no_grad,
 )
@@ -382,6 +383,94 @@ def test_compute_multi_segment_metrics_empty():
         _make_metric_sample(parent_traj_id=None),
     ]
     assert compute_multi_segment_metrics(samples) == {}
+
+
+# ---------------------------------------------------------------------------
+# compute_prewarm_metrics
+# ---------------------------------------------------------------------------
+
+
+def _prewarm_sample(
+    *,
+    parent_traj_id=None,
+    prewarm_requested=False,
+    prewarm_hit=None,
+    prewarm_wait_seconds=None,
+    remove_sample=False,
+):
+    meta: dict[str, Any] = {}
+    if parent_traj_id is not None:
+        meta["parent_traj_id"] = parent_traj_id
+    if prewarm_requested:
+        meta["prewarm_requested"] = True
+    if prewarm_hit is not None:
+        meta["prewarm_hit"] = prewarm_hit
+    if prewarm_wait_seconds is not None:
+        meta["prewarm_wait_seconds"] = prewarm_wait_seconds
+    return SimpleNamespace(metadata=meta, remove_sample=remove_sample)
+
+
+def test_compute_prewarm_metrics_hit_rate_and_wait():
+    samples = [
+        # trajectory t1: prewarm hit, 3 segments share the same metadata
+        _prewarm_sample(parent_traj_id="t1", prewarm_requested=True, prewarm_hit=1,
+                        prewarm_wait_seconds=0.5),
+        _prewarm_sample(parent_traj_id="t1", prewarm_requested=True, prewarm_hit=1,
+                        prewarm_wait_seconds=0.5),
+        _prewarm_sample(parent_traj_id="t1", prewarm_requested=True, prewarm_hit=1,
+                        prewarm_wait_seconds=0.5),
+        # trajectory t2: prewarm hit with a longer wait
+        _prewarm_sample(parent_traj_id="t2", prewarm_requested=True, prewarm_hit=1,
+                        prewarm_wait_seconds=1.5),
+        # trajectory t3: prewarm miss (fell back to inline init)
+        _prewarm_sample(parent_traj_id="t3", prewarm_requested=True, prewarm_hit=0),
+    ]
+    metrics = compute_prewarm_metrics(samples)
+    assert metrics["prewarm/num_requested"] == 3
+    assert metrics["prewarm/num_hits"] == 2
+    assert metrics["prewarm/num_misses"] == 1
+    assert metrics["prewarm/hit_rate"] == pytest.approx(2 / 3)
+    assert metrics["prewarm/wait_seconds_mean"] == pytest.approx(1.0)
+    assert metrics["prewarm/wait_seconds_max"] == pytest.approx(1.5)
+    assert metrics["prewarm/wait_seconds_min"] == pytest.approx(0.5)
+
+
+def test_compute_prewarm_metrics_ignores_non_requested_trajectories():
+    """Rollout modes that never prewarm (e.g. sync) leave no prewarm_requested
+    marker, so no prewarm metrics are emitted at all."""
+    samples = [
+        _prewarm_sample(parent_traj_id="t1"),
+        _prewarm_sample(parent_traj_id="t2"),
+    ]
+    assert compute_prewarm_metrics(samples) == {}
+    assert compute_prewarm_metrics([]) == {}
+
+
+def test_compute_prewarm_metrics_counts_aborted_trajectories():
+    """A prewarm hit reflects sandbox reuse and must count even when the
+    rollout later aborted (remove_sample=True)."""
+    samples = [
+        _prewarm_sample(parent_traj_id="t1", prewarm_requested=True, prewarm_hit=1,
+                        prewarm_wait_seconds=0.2, remove_sample=True),
+        _prewarm_sample(parent_traj_id="t2", prewarm_requested=True, prewarm_hit=0),
+    ]
+    metrics = compute_prewarm_metrics(samples)
+    assert metrics["prewarm/num_requested"] == 2
+    assert metrics["prewarm/num_hits"] == 1
+    assert metrics["prewarm/hit_rate"] == pytest.approx(0.5)
+
+
+def test_compute_prewarm_metrics_all_miss_reports_zero_hit_rate():
+    samples = [
+        _prewarm_sample(parent_traj_id="t1", prewarm_requested=True, prewarm_hit=0),
+        _prewarm_sample(parent_traj_id="t2", prewarm_requested=True, prewarm_hit=0),
+    ]
+    metrics = compute_prewarm_metrics(samples)
+    assert metrics["prewarm/num_requested"] == 2
+    assert metrics["prewarm/num_hits"] == 0
+    assert metrics["prewarm/hit_rate"] == pytest.approx(0.0)
+    # No hits → no wait-time distribution.
+    assert "prewarm/wait_seconds_mean" not in metrics
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prewarm_scheduler.py
+++ b/tests/test_prewarm_scheduler.py
@@ -114,6 +114,31 @@ def test_prefetch_passes_explicit_group_ownership_and_queues_groups() -> None:
     assert not hasattr(subject, "_group_sids")
 
 
+def test_prefetch_marks_requested_only_for_started_prewarms() -> None:
+    """Samples whose prewarm actually started get a ``prewarm_requested``
+    marker so dispatch can attribute hit/miss; skipped ones stay unmarked."""
+    started_sample = sample()
+    skipped_sample = sample()
+    group = [started_sample, skipped_sample]
+    buffer = FakeDataBuffer([group])
+
+    with patch(
+        "dressage.rollout.prewarm.scheduler.get_paddock_from_env",
+        return_value=object(),
+    ), patch(
+        "dressage.rollout.prewarm.scheduler.paddock_env_args_from_metadata",
+        return_value={},
+    ), patch(
+        "dressage.rollout.prewarm.scheduler.start_prewarm",
+        side_effect=["bbs-started", None],
+    ):
+        subject = scheduler(enabled=True, ahead=1)
+        subject.do_prefetch(buffer)
+
+    assert started_sample.metadata.get("prewarm_requested") is True
+    assert "prewarm_requested" not in skipped_sample.metadata
+
+
 def test_prefetch_keeps_group_when_paddock_or_start_is_unavailable() -> None:
     paddock_failure_group = [sample()]
     start_skip_group = [sample()]


### PR DESCRIPTION
### What
Adds wandb metrics for sandbox prewarming so its effectiveness is observable during training.

New prewarm/* metrics (per rollout step):

prewarm/hit_rate – share of prewarm-requested trajectories that reused a ready sandbox
prewarm/num_requested, prewarm/num_hits, prewarm/num_misses
prewarm/wait_seconds_mean|max|min – claim wait on hit

### How
Metadata-driven, mirroring the existing staleness/* pattern (zero new deps):

Scheduler stamps prewarm_requested on samples whose prewarm actually started.
Dispatch records prewarm_hit / prewarm_wait_seconds after claim_prewarm.
New pure function compute_prewarm_metrics aggregates per trajectory and is wired into the sync / fully_async / partial_async entrypoints; metrics ride through RolloutFnTrainOutput.metrics.
Registers wandb.define_metric("prewarm/*", step_metric="rollout/step").
Only trajectories that actually requested a prewarm are counted, so non-prewarmed modes (e.g. sync) emit no prewarm metrics instead of a misleading 0% hit rate.

### Testing
pytest – unit tests for the aggregator, scheduler marking, and wandb registration. All green (no GPU / sandbox / wandb backend required).