### PR TITLE
feat(proxy): keep long-running model requests alive with SSE heartbeats

### DIFF
--- a/blackbox_server/adapters/base.py
+++ b/blackbox_server/adapters/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Protocol
 
@@ -13,6 +14,9 @@ from blackbox_server.core.models import (
     SessionContext,
     TurnContext,
 )
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class BackendError(Exception):
@@ -117,7 +121,10 @@ class BackendContextOverflowError(BackendError):
 def backend_context_overflow_from_proxy_payload(
     payload: object,
 ) -> BackendContextOverflowError | None:
-    if not isinstance(payload, dict) or payload.get("error") != "context_overflow":
+    if (
+        not isinstance(payload, dict)
+        or (payload.get("code") or payload.get("error")) != "context_overflow"
+    ):
         return None
     details = payload.get("details")
     if not isinstance(details, dict):
@@ -163,6 +170,30 @@ def _maybe_int(value: object) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _failed_upstream_backend_error(
+    payload: dict[str, Any],
+    original_error: BaseException | None,
+) -> BackendTransportError:
+    parts: list[str] = []
+    if original_error is not None:
+        parts.append(str(original_error))
+    message = payload.get("message")
+    if message:
+        parts.append(f"upstream error: {message}")
+    request_path = payload.get("request_path")
+    if request_path:
+        parts.append(f"failed upstream payload: {request_path}")
+    response_path = payload.get("response_path")
+    if response_path:
+        parts.append(f"failed upstream response: {response_path}")
+    dump_error = payload.get("dump_error")
+    if dump_error:
+        parts.append(f"failed upstream dump error: {dump_error}")
+    return BackendTransportError(
+        "; ".join(parts) or "Dressage proxy upstream request failed."
+    )
 
 
 class BackendAdapter(ABC):
@@ -257,6 +288,12 @@ class BackendAdapter(ABC):
             if typed_error is not None:
                 raise typed_error
             return result
+        except asyncio.CancelledError:
+            if not task.done():
+                task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+            raise
         finally:
             if not max_steps_task.done():
                 max_steps_task.cancel()
@@ -275,6 +312,63 @@ class BackendAdapter(ABC):
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await asyncio.wait_for(task, timeout=2.0)
+
+    async def _drain_and_raise_proxy_failure(
+        self,
+        proxy: Any,
+        *,
+        original_error: BaseException | None = None,
+        drain_timeout: float | None = None,
+    ) -> None:
+        """Drain the proxy before consuming any failure recorded by its stream."""
+        if proxy is None:
+            if original_error is not None:
+                raise original_error
+            return
+
+        drain_error: asyncio.TimeoutError | None = None
+        if hasattr(proxy, "drain_turn"):
+            try:
+                await proxy.drain_turn(timeout=drain_timeout)
+            except asyncio.TimeoutError as exc:
+                drain_error = exc
+                LOGGER.warning(
+                    "Timed out draining rollout proxy before consuming failure "
+                    "markers; attribution may be incomplete."
+                )
+
+        if hasattr(proxy, "consume_context_overflow_error"):
+            payload = await proxy.consume_context_overflow_error()
+            typed_error = backend_context_overflow_from_proxy_payload(payload)
+            if typed_error is not None:
+                raise typed_error from original_error
+
+        if hasattr(proxy, "consume_rollout_invalidated_error"):
+            payload = await proxy.consume_rollout_invalidated_error()
+            if payload is not None:
+                error = (
+                    payload.get("code")
+                    or payload.get("error")
+                    or "rollout_invalidated"
+                )
+                message = (
+                    payload.get("message") or "Dressage rollout was invalidated."
+                )
+                raise BackendTransportError(
+                    f"Dressage proxy {error}: {message}"
+                ) from original_error
+
+        if hasattr(proxy, "consume_failed_upstream_error"):
+            payload = await proxy.consume_failed_upstream_error()
+            if payload is not None:
+                raise _failed_upstream_backend_error(
+                    payload, original_error
+                ) from original_error
+
+        if original_error is not None:
+            raise original_error
+        if drain_error is not None:
+            raise drain_error
 
     @abstractmethod
     async def shutdown(self) -> None:

--- a/blackbox_server/adapters/claude_code.py
+++ b/blackbox_server/adapters/claude_code.py
@@ -20,10 +20,10 @@ from pydantic import BaseModel, ConfigDict, Field
 from blackbox_server.adapters.base import (
     BackendAdapter,
     BackendCapabilities,
+    BackendError,
     BackendProcessError,
     BackendProtocolError,
     BackendTransportError,
-    backend_context_overflow_from_proxy_payload,
 )
 from blackbox_server.core.models import (
     AdapterResponse,
@@ -357,7 +357,7 @@ class ClaudeCodeAdapter(BackendAdapter):
                 turn_context.turn_id, backend_session_id=backend_session_id
             )
 
-        success = False
+        proxy_failure_checked = False
         try:
             task = asyncio.create_task(
                 self._run_claude_turn(
@@ -366,46 +366,52 @@ class ClaudeCodeAdapter(BackendAdapter):
                     session_state=session_state,
                 )
             )
-            try:
-                (
-                    outputs,
-                    trace_events,
-                    usage,
-                ) = await self._await_backend_task_or_proxy_max_steps(
-                    task,
-                    session_context=session_context,
-                    proxy=self._proxy,
-                )
-            except BackendTransportError as exc:
-                await self._raise_if_proxy_context_overflow()
-                await self._raise_if_proxy_rollout_invalidated()
-                await self._raise_with_proxy_failed_upstream(exc)
+            (
+                outputs,
+                trace_events,
+                usage,
+            ) = await self._await_backend_task_or_proxy_max_steps(
+                task,
+                session_context=session_context,
+                proxy=self._proxy,
+            )
             if self._proxy is not None:
-                await self._proxy.drain_turn(
-                    timeout=self._remaining_timeout(
-                        deadline, operation="wait for rollout proxy drain"
-                    )
+                proxy_drain_timeout = self._remaining_timeout(
+                    deadline,
+                    operation="wait for rollout proxy drain",
                 )
-                await self._raise_if_proxy_context_overflow()
-                await self._raise_if_proxy_rollout_invalidated()
+                proxy_failure_checked = True
+                await self._drain_and_raise_proxy_failure(
+                    self._proxy,
+                    drain_timeout=proxy_drain_timeout,
+                )
             session_context.backend_session_id = backend_session_id
-            success = True
             return AdapterResponse(
                 outputs=outputs,
                 trace_events=trace_events,
                 usage=usage,
                 backend_session_id=backend_session_id,
             )
+        except (BackendError, asyncio.TimeoutError) as exc:
+            if proxy_failure_checked:
+                raise
+            proxy_failure_checked = True
+            await self._drain_and_raise_proxy_failure(
+                self._proxy,
+                original_error=exc,
+                drain_timeout=2.0,
+            )
         finally:
             if self._proxy is not None:
-                drain_timeout = None if success else 2.0
                 try:
-                    await self._proxy.drain_turn(timeout=drain_timeout)
-                except asyncio.TimeoutError:
-                    LOGGER.warning(
-                        "Timed out draining rollout proxy requests for turn %s",
-                        turn_context.turn_id,
-                    )
+                    if not proxy_failure_checked:
+                        try:
+                            await self._proxy.drain_turn(timeout=2.0)
+                        except asyncio.TimeoutError:
+                            LOGGER.warning(
+                                "Timed out draining rollout proxy requests for turn %s",
+                                turn_context.turn_id,
+                            )
                 finally:
                     await self._proxy.clear_turn()
 
@@ -694,53 +700,6 @@ class ClaudeCodeAdapter(BackendAdapter):
         if remaining <= 0:
             raise asyncio.TimeoutError(f"Timed out before {operation}.")
         return remaining
-
-    async def _raise_if_proxy_context_overflow(self) -> None:
-        if self._proxy is None:
-            return
-        if not hasattr(self._proxy, "consume_context_overflow_error"):
-            return
-        payload = await self._proxy.consume_context_overflow_error()
-        typed_error = backend_context_overflow_from_proxy_payload(payload)
-        if typed_error is not None:
-            raise typed_error
-
-    async def _raise_if_proxy_rollout_invalidated(self) -> None:
-        if self._proxy is None:
-            return
-        if not hasattr(self._proxy, "consume_rollout_invalidated_error"):
-            return
-        payload = await self._proxy.consume_rollout_invalidated_error()
-        if payload is None:
-            return
-        error = payload.get("error") or "rollout_invalidated"
-        message = payload.get("message") or "Dressage rollout was invalidated."
-        raise BackendTransportError(f"Dressage proxy {error}: {message}")
-
-    async def _raise_with_proxy_failed_upstream(
-        self, exc: BackendTransportError
-    ) -> None:
-        if self._proxy is None:
-            raise exc
-        if not hasattr(self._proxy, "consume_failed_upstream_error"):
-            raise exc
-        payload = await self._proxy.consume_failed_upstream_error()
-        if payload is None:
-            raise exc
-        parts = [str(exc)]
-        message = payload.get("message")
-        if message:
-            parts.append(f"upstream error: {message}")
-        request_path = payload.get("request_path")
-        if request_path:
-            parts.append(f"failed upstream payload: {request_path}")
-        response_path = payload.get("response_path")
-        if response_path:
-            parts.append(f"failed upstream response: {response_path}")
-        dump_error = payload.get("dump_error")
-        if dump_error:
-            parts.append(f"failed upstream dump error: {dump_error}")
-        raise BackendTransportError("; ".join(parts)) from exc
 
     async def _terminate_active_process(self) -> bool:
         process = self._process

--- a/blackbox_server/adapters/codex.py
+++ b/blackbox_server/adapters/codex.py
@@ -22,10 +22,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from blackbox_server.adapters.base import (
     BackendAdapter,
     BackendCapabilities,
+    BackendError,
     BackendProcessError,
     BackendProtocolError,
     BackendTransportError,
-    backend_context_overflow_from_proxy_payload,
 )
 from blackbox_server.core.models import (
     AdapterResponse,
@@ -472,7 +472,7 @@ class CodexAdapter(BackendAdapter):
                 backend_session_id=target_backend_session_id,
             )
 
-        success = False
+        proxy_failure_checked = False
         try:
             task = asyncio.create_task(
                 self._run_codex_turn(
@@ -481,16 +481,11 @@ class CodexAdapter(BackendAdapter):
                     session_state=session_state,
                 )
             )
-            try:
-                result = await self._await_backend_task_or_proxy_max_steps(
-                    task,
-                    session_context=session_context,
-                    proxy=self._proxy,
-                )
-            except BackendTransportError as exc:
-                await self._raise_if_proxy_context_overflow()
-                await self._raise_if_proxy_rollout_invalidated()
-                await self._raise_with_proxy_failed_upstream(exc)
+            result = await self._await_backend_task_or_proxy_max_steps(
+                task,
+                session_context=session_context,
+                proxy=self._proxy,
+            )
             if result.backend_session_id:
                 target_backend_session_id = result.backend_session_id
                 if self._proxy is not None:
@@ -498,31 +493,42 @@ class CodexAdapter(BackendAdapter):
                         target_backend_session_id
                     )
             if self._proxy is not None:
-                await self._proxy.drain_turn(
-                    timeout=self._remaining_timeout(
-                        deadline, operation="wait for rollout proxy drain"
-                    )
+                proxy_drain_timeout = self._remaining_timeout(
+                    deadline,
+                    operation="wait for rollout proxy drain",
                 )
-                await self._raise_if_proxy_context_overflow()
-                await self._raise_if_proxy_rollout_invalidated()
+                proxy_failure_checked = True
+                await self._drain_and_raise_proxy_failure(
+                    self._proxy,
+                    drain_timeout=proxy_drain_timeout,
+                )
             session_context.backend_session_id = target_backend_session_id
-            success = True
             return AdapterResponse(
                 outputs=result.outputs,
                 trace_events=result.trace_events,
                 usage=result.usage,
                 backend_session_id=target_backend_session_id,
             )
+        except (BackendError, asyncio.TimeoutError) as exc:
+            if proxy_failure_checked:
+                raise
+            proxy_failure_checked = True
+            await self._drain_and_raise_proxy_failure(
+                self._proxy,
+                original_error=exc,
+                drain_timeout=2.0,
+            )
         finally:
             if self._proxy is not None:
-                drain_timeout = None if success else 2.0
                 try:
-                    await self._proxy.drain_turn(timeout=drain_timeout)
-                except asyncio.TimeoutError:
-                    LOGGER.warning(
-                        "Timed out draining rollout proxy requests for turn %s",
-                        turn_context.turn_id,
-                    )
+                    if not proxy_failure_checked:
+                        try:
+                            await self._proxy.drain_turn(timeout=2.0)
+                        except asyncio.TimeoutError:
+                            LOGGER.warning(
+                                "Timed out draining rollout proxy requests for turn %s",
+                                turn_context.turn_id,
+                            )
                 finally:
                     await self._proxy.clear_turn()
 
@@ -803,53 +809,6 @@ class CodexAdapter(BackendAdapter):
         if remaining <= 0:
             raise asyncio.TimeoutError(f"Timed out before {operation}.")
         return remaining
-
-    async def _raise_if_proxy_context_overflow(self) -> None:
-        if self._proxy is None:
-            return
-        if not hasattr(self._proxy, "consume_context_overflow_error"):
-            return
-        payload = await self._proxy.consume_context_overflow_error()
-        typed_error = backend_context_overflow_from_proxy_payload(payload)
-        if typed_error is not None:
-            raise typed_error
-
-    async def _raise_if_proxy_rollout_invalidated(self) -> None:
-        if self._proxy is None:
-            return
-        if not hasattr(self._proxy, "consume_rollout_invalidated_error"):
-            return
-        payload = await self._proxy.consume_rollout_invalidated_error()
-        if payload is None:
-            return
-        error = payload.get("error") or "rollout_invalidated"
-        message = payload.get("message") or "Dressage rollout was invalidated."
-        raise BackendTransportError(f"Dressage proxy {error}: {message}")
-
-    async def _raise_with_proxy_failed_upstream(
-        self, exc: BackendTransportError
-    ) -> None:
-        if self._proxy is None:
-            raise exc
-        if not hasattr(self._proxy, "consume_failed_upstream_error"):
-            raise exc
-        payload = await self._proxy.consume_failed_upstream_error()
-        if payload is None:
-            raise exc
-        parts = [str(exc)]
-        message = payload.get("message")
-        if message:
-            parts.append(f"upstream error: {message}")
-        request_path = payload.get("request_path")
-        if request_path:
-            parts.append(f"failed upstream payload: {request_path}")
-        response_path = payload.get("response_path")
-        if response_path:
-            parts.append(f"failed upstream response: {response_path}")
-        dump_error = payload.get("dump_error")
-        if dump_error:
-            parts.append(f"failed upstream dump error: {dump_error}")
-        raise BackendTransportError("; ".join(parts)) from exc
 
     async def _terminate_active_process(self) -> bool:
         process = self._process

--- a/blackbox_server/adapters/openclaw.py
+++ b/blackbox_server/adapters/openclaw.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from blackbox_server.adapters.base import (
     BackendAdapter,
     BackendCapabilities,
+    BackendError,
     BackendMaxStepsExceededError,
     BackendProcessError,
     BackendProtocolError,
@@ -201,7 +202,7 @@ class OpenClawAdapter(BackendAdapter):
         if self._proxy is not None:
             await self._proxy.open_turn(turn_context.turn_id, backend_session_id=backend_session_id)
 
-        success = False
+        proxy_failure_checked = False
         try:
             chat_task = asyncio.create_task(
                 self._post_chat_completions(
@@ -217,11 +218,15 @@ class OpenClawAdapter(BackendAdapter):
                 proxy=self._proxy,
             )
             if self._proxy is not None:
-                await self._proxy.drain_turn(
-                    timeout=self._remaining_timeout(deadline, operation="wait for rollout proxy drain")
+                proxy_drain_timeout = self._remaining_timeout(
+                    deadline,
+                    operation="wait for rollout proxy drain",
                 )
-                await self._raise_if_proxy_context_overflow()
-                await self._raise_if_proxy_rollout_invalidated()
+                proxy_failure_checked = True
+                await self._drain_and_raise_proxy_failure(
+                    self._proxy,
+                    drain_timeout=proxy_drain_timeout,
+                )
 
             _raise_if_openclaw_max_steps_exceeded(raw, self._options)
 
@@ -229,20 +234,32 @@ class OpenClawAdapter(BackendAdapter):
                 turn_context.turn_id,
                 raw,
             )
-            success = True
             return AdapterResponse(
                 outputs=outputs,
                 trace_events=trace_events,
                 usage=usage,
                 backend_session_id=backend_session_id,
             )
+        except (BackendError, asyncio.TimeoutError) as exc:
+            if proxy_failure_checked:
+                raise
+            proxy_failure_checked = True
+            await self._drain_and_raise_proxy_failure(
+                self._proxy,
+                original_error=exc,
+                drain_timeout=2.0,
+            )
         finally:
             if self._proxy is not None:
-                drain_timeout = None if success else 2.0
                 try:
-                    await self._proxy.drain_turn(timeout=drain_timeout)
-                except asyncio.TimeoutError:
-                    LOGGER.warning("Timed out draining rollout proxy requests for turn %s", turn_context.turn_id)
+                    if not proxy_failure_checked:
+                        try:
+                            await self._proxy.drain_turn(timeout=2.0)
+                        except asyncio.TimeoutError:
+                            LOGGER.warning(
+                                "Timed out draining rollout proxy requests for turn %s",
+                                turn_context.turn_id,
+                            )
                 finally:
                     await self._proxy.clear_turn()
 
@@ -864,29 +881,6 @@ class OpenClawAdapter(BackendAdapter):
             sock.bind(("127.0.0.1", 0))
             sock.listen(1)
             return int(sock.getsockname()[1])
-
-    async def _raise_if_proxy_context_overflow(self) -> None:
-        if self._proxy is None:
-            return
-        if not hasattr(self._proxy, "consume_context_overflow_error"):
-            return
-        payload = await self._proxy.consume_context_overflow_error()
-        typed_error = backend_context_overflow_from_proxy_payload(payload)
-        if typed_error is not None:
-            raise typed_error
-
-    async def _raise_if_proxy_rollout_invalidated(self) -> None:
-        if self._proxy is None:
-            return
-        if not hasattr(self._proxy, "consume_rollout_invalidated_error"):
-            return
-        payload = await self._proxy.consume_rollout_invalidated_error()
-        if payload is None:
-            return
-        error = payload.get("error") or "rollout_invalidated"
-        message = payload.get("message") or "Dressage rollout was invalidated."
-        raise BackendTransportError(f"Dressage proxy {error}: {message}")
-
 
 def _maybe_int(value: Any) -> int | None:
     if value is None or isinstance(value, bool):

--- a/blackbox_server/adapters/opencode.py
+++ b/blackbox_server/adapters/opencode.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from blackbox_server.adapters.base import (
     BackendAdapter,
     BackendCapabilities,
+    BackendError,
     BackendMaxStepsExceededError,
     BackendProcessError,
     BackendProtocolError,
@@ -200,7 +201,7 @@ class OpencodeAdapter(BackendAdapter):
         if self._proxy is not None:
             await self._proxy.open_turn(turn_context.turn_id, backend_session_id=session_context.backend_session_id)
 
-        success = False
+        proxy_failure_checked = False
         try:
             backend_session_id = await self._ensure_backend_session(
                 session_context,
@@ -232,11 +233,15 @@ class OpencodeAdapter(BackendAdapter):
             # Wait until the proxied upstream turn has fully drained so we do not
             # snapshot opencode history before the final assistant/tool messages land.
             if self._proxy is not None:
-                await self._proxy.drain_turn(
-                    timeout=self._remaining_timeout(deadline, operation="wait for rollout proxy drain")
+                proxy_drain_timeout = self._remaining_timeout(
+                    deadline,
+                    operation="wait for rollout proxy drain",
                 )
-                await self._raise_if_proxy_context_overflow()
-                await self._raise_if_proxy_rollout_invalidated()
+                proxy_failure_checked = True
+                await self._drain_and_raise_proxy_failure(
+                    self._proxy,
+                    drain_timeout=proxy_drain_timeout,
+                )
             all_messages, outputs, trace_events, usage = await self._request_get_with_retry(
                 f"/session/{backend_session_id}/message",
                 deadline=deadline,
@@ -244,20 +249,32 @@ class OpencodeAdapter(BackendAdapter):
                 prev_msg_count=prev_msg_count,
             )
             session_context.metadata[_OC_MSG_COUNT_KEY] = len(all_messages)
-            success = True
             return AdapterResponse(
                 outputs=outputs,
                 trace_events=trace_events,
                 usage=usage,
                 backend_session_id=backend_session_id,
             )
+        except (BackendError, asyncio.TimeoutError) as exc:
+            if proxy_failure_checked:
+                raise
+            proxy_failure_checked = True
+            await self._drain_and_raise_proxy_failure(
+                self._proxy,
+                original_error=exc,
+                drain_timeout=2.0,
+            )
         finally:
             if self._proxy is not None:
-                drain_timeout = None if success else 2.0
                 try:
-                    await self._proxy.drain_turn(timeout=drain_timeout)
-                except asyncio.TimeoutError:
-                    LOGGER.warning("Timed out draining rollout proxy requests for turn %s", turn_context.turn_id)
+                    if not proxy_failure_checked:
+                        try:
+                            await self._proxy.drain_turn(timeout=2.0)
+                        except asyncio.TimeoutError:
+                            LOGGER.warning(
+                                "Timed out draining rollout proxy requests for turn %s",
+                                turn_context.turn_id,
+                            )
                 finally:
                     await self._proxy.clear_turn()
 
@@ -679,29 +696,6 @@ class OpencodeAdapter(BackendAdapter):
             sock.bind(("127.0.0.1", 0))
             sock.listen(1)
             return int(sock.getsockname()[1])
-
-    async def _raise_if_proxy_context_overflow(self) -> None:
-        if self._proxy is None:
-            return
-        if not hasattr(self._proxy, "consume_context_overflow_error"):
-            return
-        payload = await self._proxy.consume_context_overflow_error()
-        typed_error = backend_context_overflow_from_proxy_payload(payload)
-        if typed_error is not None:
-            raise typed_error
-
-    async def _raise_if_proxy_rollout_invalidated(self) -> None:
-        if self._proxy is None:
-            return
-        if not hasattr(self._proxy, "consume_rollout_invalidated_error"):
-            return
-        payload = await self._proxy.consume_rollout_invalidated_error()
-        if payload is None:
-            return
-        error = payload.get("error") or "rollout_invalidated"
-        message = payload.get("message") or "Dressage rollout was invalidated."
-        raise BackendTransportError(f"Dressage proxy {error}: {message}")
-
 
 def _maybe_int(value: Any) -> int | None:
     if value is None or isinstance(value, bool):

--- a/blackbox_server/core/server.py
+++ b/blackbox_server/core/server.py
@@ -202,9 +202,7 @@ class BlackboxServer:
 
                 remaining = deadline - loop.time()
                 if remaining <= 0:
-                    task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError, Exception):
-                        await task
+                    await self._cancel_task_safely(task)
                     raise asyncio.TimeoutError
 
                 done, pending = await asyncio.wait({task}, timeout=remaining)
@@ -212,10 +210,30 @@ class BlackboxServer:
                     return await task
                 if pending:
                     raise asyncio.TimeoutError
-        except Exception:
-            if not task.done():
-                task.cancel()
+        except asyncio.CancelledError:
+            await self._cancel_task_safely(task)
             raise
+        except Exception:
+            await self._cancel_task_safely(task)
+            raise
+
+    @staticmethod
+    async def _cancel_task_safely(task: asyncio.Task[Any]) -> None:
+        if not task.done():
+            task.cancel()
+        await BlackboxServer._wait_for_task_safely(task)
+
+    @staticmethod
+    async def _wait_for_task_safely(task: asyncio.Task[Any]) -> None:
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await task
 
     async def graceful_shutdown(self) -> None:
         if self._shutdown_started:

--- a/blackbox_server/proxy/rollout_llm_proxy.py
+++ b/blackbox_server/proxy/rollout_llm_proxy.py
@@ -6,7 +6,7 @@ import logging
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Awaitable, Callable, Literal, Mapping
 
 import httpx
 from fastapi import FastAPI, Request
@@ -21,6 +21,15 @@ DRESSAGE_ROLLOUT_INVALIDATED_ERRORS = {
     "partial_rollout_staleness_exceeded",
     "trajectory_version_changed",
 }
+_MAX_SSE_SNIFF_EVENT_BYTES = 1024 * 1024
+_SSE_BOUNDARY_SUFFIX_BYTES = 3
+_RETRYABLE_UPSTREAM_STATUSES = {429, 502, 503, 504, 522}
+_InStreamErrorKind = Literal[
+    "context_overflow",
+    "rollout_invalidated",
+    "failed_upstream",
+]
+_ModelRequestOutcome = Literal["succeeded", "retryable", "failed"]
 
 
 @dataclass
@@ -33,6 +42,7 @@ class _TurnScope:
     rollout_invalidated_error: dict[str, Any] | None = None
     max_steps_error: dict[str, Any] | None = None
     failed_upstream_error: dict[str, Any] | None = None
+    latest_successful_step: int | None = None
     drained: asyncio.Event = field(default_factory=asyncio.Event)
     max_steps_exceeded: asyncio.Event = field(default_factory=asyncio.Event)
 
@@ -721,6 +731,14 @@ class RolloutLLMProxy:
         return headers
 
     @staticmethod
+    def _request_outcome_for_status(status_code: int) -> _ModelRequestOutcome:
+        return (
+            "retryable"
+            if status_code in _RETRYABLE_UPSTREAM_STATUSES
+            else "failed"
+        )
+
+    @staticmethod
     def _set_header(headers: dict[str, str], name: str, value: str) -> None:
         for existing in list(headers):
             if existing.lower() == name.lower():
@@ -849,8 +867,31 @@ class RolloutLLMProxy:
             scope.inflight_requests += 1
             scope.drained.clear()
 
-    async def _mark_request_finished(self, scope: _TurnScope) -> None:
+    async def _mark_request_finished(
+        self,
+        snapshot: _TurnSnapshot,
+        *,
+        outcome: _ModelRequestOutcome,
+    ) -> None:
+        scope = snapshot.scope
+        if scope is None:
+            return
         async with self._scope_lock:
+            if outcome == "succeeded":
+                if (
+                    scope.latest_successful_step is None
+                    or snapshot.step > scope.latest_successful_step
+                ):
+                    scope.latest_successful_step = snapshot.step
+                failed_upstream = scope.failed_upstream_error
+                if (
+                    isinstance(failed_upstream, dict)
+                    and failed_upstream.get("status_code")
+                    in _RETRYABLE_UPSTREAM_STATUSES
+                    and isinstance(failed_upstream.get("step"), int)
+                    and failed_upstream["step"] <= scope.latest_successful_step
+                ):
+                    scope.failed_upstream_error = None
             if scope.inflight_requests > 0:
                 scope.inflight_requests -= 1
             if scope.inflight_requests == 0:
@@ -865,6 +906,7 @@ class RolloutLLMProxy:
         snapshot: _TurnSnapshot | None,
     ) -> Response:
         assert self._client is not None
+        outcome: _ModelRequestOutcome = "retryable"
         try:
             response = await self._send_plain_request(method, url, body, headers)
             if response.status_code >= 400:
@@ -886,6 +928,7 @@ class RolloutLLMProxy:
                         status_code=response.status_code,
                         response_body=response.content,
                     ):
+                        outcome = "failed"
                         return self._synthetic_anthropic_message_response()
                 await self._record_failed_upstream_error(
                     snapshot,
@@ -896,6 +939,7 @@ class RolloutLLMProxy:
                     response_headers=dict(response.headers),
                     response_body=response.content,
                 )
+                outcome = self._request_outcome_for_status(response.status_code)
                 if 500 <= response.status_code < 600:
                     return self._anthropic_non_retry_upstream_error_response(
                         upstream_status_code=response.status_code,
@@ -915,6 +959,7 @@ class RolloutLLMProxy:
             response_headers.pop("transfer-encoding", None)
             response_headers.pop("content-length", None)
             response_headers["content-type"] = "application/json"
+            outcome = "succeeded"
             return Response(
                 content=json.dumps(anthropic_payload, ensure_ascii=False).encode("utf-8"),
                 status_code=response.status_code,
@@ -923,7 +968,7 @@ class RolloutLLMProxy:
             )
         finally:
             if snapshot is not None and snapshot.scope is not None:
-                await self._mark_request_finished(snapshot.scope)
+                await self._mark_request_finished(snapshot, outcome=outcome)
 
     async def _plain_openai_responses_proxy(
         self,
@@ -935,6 +980,7 @@ class RolloutLLMProxy:
         original_request: dict[str, Any],
     ) -> Response:
         assert self._client is not None
+        outcome: _ModelRequestOutcome = "retryable"
         try:
             response = await self._send_plain_request(method, url, body, headers)
             if response.status_code >= 400:
@@ -956,6 +1002,7 @@ class RolloutLLMProxy:
                         status_code=response.status_code,
                         response_body=response.content,
                     ):
+                        outcome = "failed"
                         return self._synthetic_openai_response()
                 await self._record_failed_upstream_error(
                     snapshot,
@@ -966,6 +1013,7 @@ class RolloutLLMProxy:
                     response_headers=dict(response.headers),
                     response_body=response.content,
                 )
+                outcome = self._request_outcome_for_status(response.status_code)
             response_headers = dict(response.headers)
             response_headers.pop("content-encoding", None)
             response_headers.pop("transfer-encoding", None)
@@ -985,6 +1033,7 @@ class RolloutLLMProxy:
                 payload = {}
             responses_payload = self._chat_completion_to_openai_response(payload, original_request)
             response_headers["content-type"] = "application/json"
+            outcome = "succeeded"
             return Response(
                 content=json.dumps(responses_payload, ensure_ascii=False).encode("utf-8"),
                 status_code=response.status_code,
@@ -993,7 +1042,7 @@ class RolloutLLMProxy:
             )
         finally:
             if snapshot is not None and snapshot.scope is not None:
-                await self._mark_request_finished(snapshot.scope)
+                await self._mark_request_finished(snapshot, outcome=outcome)
 
     async def _plain_proxy(
         self,
@@ -1004,6 +1053,7 @@ class RolloutLLMProxy:
         snapshot: _TurnSnapshot | None,
     ) -> Response:
         assert self._client is not None
+        outcome: _ModelRequestOutcome = "retryable"
         try:
             response = await self._send_plain_request(method, url, body, headers)
             if response.status_code >= 400:
@@ -1025,6 +1075,7 @@ class RolloutLLMProxy:
                         status_code=response.status_code,
                         response_body=response.content,
                     ):
+                        outcome = "failed"
                         return self._synthetic_chat_completion_response()
                 await self._record_failed_upstream_error(
                     snapshot,
@@ -1035,6 +1086,9 @@ class RolloutLLMProxy:
                     response_headers=dict(response.headers),
                     response_body=response.content,
                 )
+                outcome = self._request_outcome_for_status(response.status_code)
+            else:
+                outcome = "succeeded"
             response_headers = dict(response.headers)
             response_headers.pop("content-encoding", None)
             response_headers.pop("transfer-encoding", None)
@@ -1046,7 +1100,7 @@ class RolloutLLMProxy:
             )
         finally:
             if snapshot is not None and snapshot.scope is not None:
-                await self._mark_request_finished(snapshot.scope)
+                await self._mark_request_finished(snapshot, outcome=outcome)
 
     async def _stream_proxy(
         self,
@@ -1058,64 +1112,145 @@ class RolloutLLMProxy:
         assert self._client is not None
         try:
             upstream_response = await self._send_stream_request(url, body, headers)
-        except Exception:
+        except BaseException:
             if snapshot is not None and snapshot.scope is not None:
-                await self._mark_request_finished(snapshot.scope)
+                await self._mark_request_finished(snapshot, outcome="retryable")
             raise
 
         if upstream_response.status_code >= 400:
-            error_body = await upstream_response.aread()
-            response_headers = dict(upstream_response.headers)
-            response_headers.pop("content-encoding", None)
-            response_headers.pop("transfer-encoding", None)
-            response_headers.pop("content-length", None)
-            self._log_upstream_error(
-                url=url,
-                status_code=upstream_response.status_code,
-                response_headers=dict(upstream_response.headers),
-                response_body=error_body,
-                retried=False,
-            )
-            if snapshot is not None and snapshot.scope is not None:
-                await self._record_context_overflow_error(
-                    snapshot.scope,
+            outcome: _ModelRequestOutcome = "retryable"
+            try:
+                error_body = await upstream_response.aread()
+                response_headers = dict(upstream_response.headers)
+                response_headers.pop("content-encoding", None)
+                response_headers.pop("transfer-encoding", None)
+                response_headers.pop("content-length", None)
+                self._log_upstream_error(
+                    url=url,
                     status_code=upstream_response.status_code,
+                    response_headers=dict(upstream_response.headers),
+                    response_body=error_body,
+                    retried=False,
+                )
+                if snapshot is not None and snapshot.scope is not None:
+                    await self._record_context_overflow_error(
+                        snapshot.scope,
+                        status_code=upstream_response.status_code,
+                        response_body=error_body,
+                    )
+                    if await self._record_rollout_invalidated_error(
+                        snapshot.scope,
+                        status_code=upstream_response.status_code,
+                        response_body=error_body,
+                    ):
+                        outcome = "failed"
+                        return self._synthetic_chat_completion_stream_response()
+                await self._record_failed_upstream_error(
+                    snapshot,
+                    url=url,
+                    status_code=upstream_response.status_code,
+                    request_headers=headers,
+                    request_body=body,
+                    response_headers=dict(upstream_response.headers),
                     response_body=error_body,
                 )
-                if await self._record_rollout_invalidated_error(
-                    snapshot.scope,
+                outcome = self._request_outcome_for_status(
+                    upstream_response.status_code
+                )
+                return Response(
+                    content=error_body,
                     status_code=upstream_response.status_code,
-                    response_body=error_body,
-                ):
+                    headers=response_headers,
+                )
+            finally:
+                try:
                     await upstream_response.aclose()
-                    await self._mark_request_finished(snapshot.scope)
-                    return self._synthetic_chat_completion_stream_response()
-            await self._record_failed_upstream_error(
-                snapshot,
-                url=url,
-                status_code=upstream_response.status_code,
-                request_headers=headers,
-                request_body=body,
-                response_headers=dict(upstream_response.headers),
-                response_body=error_body,
-            )
-            await upstream_response.aclose()
-            if snapshot is not None and snapshot.scope is not None:
-                await self._mark_request_finished(snapshot.scope)
-            return Response(
-                content=error_body,
-                status_code=upstream_response.status_code,
-                headers=response_headers,
-            )
+                finally:
+                    if snapshot is not None and snapshot.scope is not None:
+                        await self._mark_request_finished(snapshot, outcome=outcome)
 
         async def _forward():
+            buffer = b""
+            oversized_event = False
+            outcome: _ModelRequestOutcome = "retryable"
+            saw_retryable_error = False
+            saw_terminal_error = False
+
+            async def _rewrite_event(
+                raw_event: bytes,
+                event_bytes: bytes,
+                *,
+                terminal: bool = False,
+            ) -> bytes:
+                nonlocal saw_retryable_error, saw_terminal_error
+                sniffed = self._in_stream_error_from_sse_event(raw_event)
+                if sniffed is None:
+                    return event_bytes
+                error_status, error_body = sniffed
+                error_kind = await self._record_in_stream_error(
+                    snapshot,
+                    url=url,
+                    request_headers=headers,
+                    request_body=body,
+                    status_code=error_status,
+                    error_body=error_body,
+                )
+                if (
+                    error_kind == "failed_upstream"
+                    and self._request_outcome_for_status(error_status) == "retryable"
+                ):
+                    saw_retryable_error = True
+                else:
+                    saw_terminal_error = True
+                if error_kind != "rollout_invalidated":
+                    return event_bytes
+                rewritten = self._synthetic_chat_completion_chunk_bytes()
+                if terminal:
+                    rewritten += b"data: [DONE]\n\n"
+                return rewritten
+
             try:
                 async for chunk in upstream_response.aiter_bytes():
-                    yield chunk
+                    buffer += chunk
+                    while True:
+                        framed = _pop_sse_event_bytes(buffer)
+                        if framed is None:
+                            break
+                        raw_event, delimiter, buffer = framed
+                        event_bytes = raw_event + delimiter
+                        if oversized_event or len(raw_event) > _MAX_SSE_SNIFF_EVENT_BYTES:
+                            yield event_bytes
+                            oversized_event = False
+                            continue
+                        yield await _rewrite_event(raw_event, event_bytes)
+
+                    if len(buffer) > _MAX_SSE_SNIFF_EVENT_BYTES:
+                        oversized_event = True
+                        flush_length = len(buffer) - _SSE_BOUNDARY_SUFFIX_BYTES
+                        if flush_length > 0:
+                            yield buffer[:flush_length]
+                            buffer = buffer[flush_length:]
+                if buffer:
+                    if oversized_event:
+                        yield buffer
+                    else:
+                        yield await _rewrite_event(
+                            buffer,
+                            buffer,
+                            terminal=True,
+                        )
+                if saw_terminal_error:
+                    outcome = "failed"
+                elif saw_retryable_error:
+                    outcome = "retryable"
+                else:
+                    outcome = "succeeded"
             finally:
-                await upstream_response.aclose()
-                if snapshot is not None and snapshot.scope is not None:
-                    await self._mark_request_finished(snapshot.scope)
+                try:
+                    await upstream_response.aclose()
+                finally:
+                    if snapshot is not None and snapshot.scope is not None:
+                        await self._mark_request_finished(snapshot, outcome=outcome)
 
         response_headers = dict(upstream_response.headers)
         response_headers.pop("content-encoding", None)
@@ -1138,64 +1273,108 @@ class RolloutLLMProxy:
         assert self._client is not None
         try:
             upstream_response = await self._send_stream_request(url, body, headers)
-        except Exception:
+        except BaseException:
             if snapshot is not None and snapshot.scope is not None:
-                await self._mark_request_finished(snapshot.scope)
+                await self._mark_request_finished(snapshot, outcome="retryable")
             raise
 
         if upstream_response.status_code >= 400:
-            error_body = await upstream_response.aread()
-            self._log_upstream_error(
-                url=url,
-                status_code=upstream_response.status_code,
-                response_headers=dict(upstream_response.headers),
-                response_body=error_body,
-                retried=False,
-            )
-            if snapshot is not None and snapshot.scope is not None:
-                await self._record_context_overflow_error(
-                    snapshot.scope,
+            outcome: _ModelRequestOutcome = "retryable"
+            try:
+                error_body = await upstream_response.aread()
+                self._log_upstream_error(
+                    url=url,
+                    status_code=upstream_response.status_code,
+                    response_headers=dict(upstream_response.headers),
+                    response_body=error_body,
+                    retried=False,
+                )
+                if snapshot is not None and snapshot.scope is not None:
+                    await self._record_context_overflow_error(
+                        snapshot.scope,
+                        status_code=upstream_response.status_code,
+                        response_body=error_body,
+                    )
+                    if await self._record_rollout_invalidated_error(
+                        snapshot.scope,
+                        status_code=upstream_response.status_code,
+                        response_body=error_body,
+                    ):
+                        outcome = "failed"
+                        return self._synthetic_anthropic_message_stream_response()
+                await self._record_failed_upstream_error(
+                    snapshot,
+                    url=url,
+                    status_code=upstream_response.status_code,
+                    request_headers=headers,
+                    request_body=body,
+                    response_headers=dict(upstream_response.headers),
+                    response_body=error_body,
+                )
+                outcome = self._request_outcome_for_status(
+                    upstream_response.status_code
+                )
+                if 500 <= upstream_response.status_code < 600:
+                    return self._anthropic_non_retry_upstream_error_response(
+                        upstream_status_code=upstream_response.status_code,
+                        response_body=error_body,
+                    )
+                return self._anthropic_error_response_from_bytes(
                     status_code=upstream_response.status_code,
                     response_body=error_body,
                 )
-                if await self._record_rollout_invalidated_error(
-                    snapshot.scope,
-                    status_code=upstream_response.status_code,
-                    response_body=error_body,
-                ):
+            finally:
+                try:
                     await upstream_response.aclose()
-                    await self._mark_request_finished(snapshot.scope)
-                    return self._synthetic_anthropic_message_stream_response()
-            await self._record_failed_upstream_error(
-                snapshot,
-                url=url,
-                status_code=upstream_response.status_code,
-                request_headers=headers,
-                request_body=body,
-                response_headers=dict(upstream_response.headers),
-                response_body=error_body,
-            )
-            await upstream_response.aclose()
-            if snapshot is not None and snapshot.scope is not None:
-                await self._mark_request_finished(snapshot.scope)
-            if 500 <= upstream_response.status_code < 600:
-                return self._anthropic_non_retry_upstream_error_response(
-                    upstream_status_code=upstream_response.status_code,
-                    response_body=error_body,
-                )
-            return self._anthropic_error_response_from_bytes(
-                status_code=upstream_response.status_code,
-                response_body=error_body,
-            )
+                finally:
+                    if snapshot is not None and snapshot.scope is not None:
+                        await self._mark_request_finished(snapshot, outcome=outcome)
 
         async def _forward():
+            outcome: _ModelRequestOutcome = "retryable"
+            saw_retryable_error = False
+            saw_terminal_error = False
+
+            async def _on_in_stream_error(
+                error_status: int,
+                error_body: bytes,
+            ) -> _InStreamErrorKind:
+                nonlocal saw_retryable_error, saw_terminal_error
+                error_kind = await self._record_in_stream_error(
+                    snapshot,
+                    url=url,
+                    request_headers=headers,
+                    request_body=body,
+                    status_code=error_status,
+                    error_body=error_body,
+                )
+                if (
+                    error_kind == "failed_upstream"
+                    and self._request_outcome_for_status(error_status) == "retryable"
+                ):
+                    saw_retryable_error = True
+                else:
+                    saw_terminal_error = True
+                return error_kind
+
             try:
-                async for event in self._iter_anthropic_events_from_openai_stream(upstream_response):
+                async for event in self._iter_anthropic_events_from_openai_stream(
+                    upstream_response,
+                    on_in_stream_error=_on_in_stream_error,
+                ):
                     yield event
+                if saw_terminal_error:
+                    outcome = "failed"
+                elif saw_retryable_error:
+                    outcome = "retryable"
+                else:
+                    outcome = "succeeded"
             finally:
-                await upstream_response.aclose()
-                if snapshot is not None and snapshot.scope is not None:
-                    await self._mark_request_finished(snapshot.scope)
+                try:
+                    await upstream_response.aclose()
+                finally:
+                    if snapshot is not None and snapshot.scope is not None:
+                        await self._mark_request_finished(snapshot, outcome=outcome)
 
         return StreamingResponse(
             _forward(),
@@ -1214,67 +1393,109 @@ class RolloutLLMProxy:
         assert self._client is not None
         try:
             upstream_response = await self._send_stream_request(url, body, headers)
-        except Exception:
+        except BaseException:
             if snapshot is not None and snapshot.scope is not None:
-                await self._mark_request_finished(snapshot.scope)
+                await self._mark_request_finished(snapshot, outcome="retryable")
             raise
 
         if upstream_response.status_code >= 400:
-            error_body = await upstream_response.aread()
-            response_headers = dict(upstream_response.headers)
-            response_headers.pop("content-encoding", None)
-            response_headers.pop("transfer-encoding", None)
-            response_headers.pop("content-length", None)
-            self._log_upstream_error(
-                url=url,
-                status_code=upstream_response.status_code,
-                response_headers=dict(upstream_response.headers),
-                response_body=error_body,
-                retried=False,
-            )
-            if snapshot is not None and snapshot.scope is not None:
-                await self._record_context_overflow_error(
-                    snapshot.scope,
+            outcome: _ModelRequestOutcome = "retryable"
+            try:
+                error_body = await upstream_response.aread()
+                response_headers = dict(upstream_response.headers)
+                response_headers.pop("content-encoding", None)
+                response_headers.pop("transfer-encoding", None)
+                response_headers.pop("content-length", None)
+                self._log_upstream_error(
+                    url=url,
                     status_code=upstream_response.status_code,
+                    response_headers=dict(upstream_response.headers),
+                    response_body=error_body,
+                    retried=False,
+                )
+                if snapshot is not None and snapshot.scope is not None:
+                    await self._record_context_overflow_error(
+                        snapshot.scope,
+                        status_code=upstream_response.status_code,
+                        response_body=error_body,
+                    )
+                    if await self._record_rollout_invalidated_error(
+                        snapshot.scope,
+                        status_code=upstream_response.status_code,
+                        response_body=error_body,
+                    ):
+                        outcome = "failed"
+                        return self._synthetic_openai_response_stream_response()
+                await self._record_failed_upstream_error(
+                    snapshot,
+                    url=url,
+                    status_code=upstream_response.status_code,
+                    request_headers=headers,
+                    request_body=body,
+                    response_headers=dict(upstream_response.headers),
                     response_body=error_body,
                 )
-                if await self._record_rollout_invalidated_error(
-                    snapshot.scope,
+                outcome = self._request_outcome_for_status(
+                    upstream_response.status_code
+                )
+                return Response(
+                    content=error_body,
                     status_code=upstream_response.status_code,
-                    response_body=error_body,
-                ):
+                    headers=response_headers,
+                )
+            finally:
+                try:
                     await upstream_response.aclose()
-                    await self._mark_request_finished(snapshot.scope)
-                    return self._synthetic_openai_response_stream_response()
-            await self._record_failed_upstream_error(
-                snapshot,
-                url=url,
-                status_code=upstream_response.status_code,
-                request_headers=headers,
-                request_body=body,
-                response_headers=dict(upstream_response.headers),
-                response_body=error_body,
-            )
-            await upstream_response.aclose()
-            if snapshot is not None and snapshot.scope is not None:
-                await self._mark_request_finished(snapshot.scope)
-            return Response(
-                content=error_body,
-                status_code=upstream_response.status_code,
-                headers=response_headers,
-            )
+                finally:
+                    if snapshot is not None and snapshot.scope is not None:
+                        await self._mark_request_finished(snapshot, outcome=outcome)
 
         async def _forward():
+            outcome: _ModelRequestOutcome = "retryable"
+            saw_retryable_error = False
+            saw_terminal_error = False
+
+            async def _on_in_stream_error(
+                error_status: int,
+                error_body: bytes,
+            ) -> _InStreamErrorKind:
+                nonlocal saw_retryable_error, saw_terminal_error
+                error_kind = await self._record_in_stream_error(
+                    snapshot,
+                    url=url,
+                    request_headers=headers,
+                    request_body=body,
+                    status_code=error_status,
+                    error_body=error_body,
+                )
+                if (
+                    error_kind == "failed_upstream"
+                    and self._request_outcome_for_status(error_status) == "retryable"
+                ):
+                    saw_retryable_error = True
+                else:
+                    saw_terminal_error = True
+                return error_kind
+
             try:
                 async for event in self._iter_openai_response_events_from_chat_stream(
                     upstream_response,
                     original_request,
+                    on_in_stream_error=_on_in_stream_error,
                 ):
                     yield event
+                if saw_terminal_error:
+                    outcome = "failed"
+                elif saw_retryable_error:
+                    outcome = "retryable"
+                else:
+                    outcome = "succeeded"
             finally:
-                await upstream_response.aclose()
-                if snapshot is not None and snapshot.scope is not None:
-                    await self._mark_request_finished(snapshot.scope)
+                try:
+                    await upstream_response.aclose()
+                finally:
+                    if snapshot is not None and snapshot.scope is not None:
+                        await self._mark_request_finished(snapshot, outcome=outcome)
 
         return StreamingResponse(
             _forward(),
@@ -1351,7 +1572,26 @@ class RolloutLLMProxy:
             response_body=response_body,
         )
         async with self._scope_lock:
-            snapshot.scope.failed_upstream_error = payload
+            scope = snapshot.scope
+            new_retryable = status_code in _RETRYABLE_UPSTREAM_STATUSES
+            if (
+                new_retryable
+                and scope.latest_successful_step is not None
+                and snapshot.step <= scope.latest_successful_step
+            ):
+                return
+            existing = scope.failed_upstream_error
+            if isinstance(existing, dict):
+                existing_retryable = (
+                    existing.get("status_code") in _RETRYABLE_UPSTREAM_STATUSES
+                )
+                if not existing_retryable and new_retryable:
+                    return
+                if existing_retryable == new_retryable:
+                    existing_step = existing.get("step")
+                    if isinstance(existing_step, int) and existing_step > snapshot.step:
+                        return
+            scope.failed_upstream_error = payload
 
     def _failed_upstream_error_payload(
         self,
@@ -1551,15 +1791,88 @@ class RolloutLLMProxy:
         *,
         status_code: int,
         response_body: bytes,
-    ) -> None:
+    ) -> bool:
         payload = self._context_overflow_payload_from_response(
             status_code=status_code,
             response_body=response_body,
         )
         if payload is None:
-            return
+            return False
         async with self._scope_lock:
             scope.context_overflow_error = payload
+        return True
+
+    @staticmethod
+    def _in_stream_error_from_chunk(chunk: dict[str, Any]) -> tuple[int, bytes] | None:
+        """Detect an error event emitted after heartbeat streaming starts."""
+        error = chunk.get("error")
+        if not isinstance(error, dict):
+            return None
+        status_code = error.get("status_code")
+        if type(status_code) is not int or not 400 <= status_code <= 599:
+            return None
+        return status_code, json.dumps(error, ensure_ascii=False).encode("utf-8")
+
+    @staticmethod
+    def _in_stream_error_from_sse_event(raw_event: bytes) -> tuple[int, bytes] | None:
+        try:
+            text = raw_event.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+        for payload in _payloads_from_sse_event(text):
+            if payload == "[DONE]":
+                continue
+            try:
+                parsed = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            sniffed = RolloutLLMProxy._in_stream_error_from_chunk(parsed)
+            if sniffed is not None:
+                return sniffed
+        return None
+
+    async def _record_in_stream_error(
+        self,
+        snapshot: _TurnSnapshot | None,
+        *,
+        url: str,
+        request_headers: dict[str, str],
+        request_body: bytes,
+        status_code: int,
+        error_body: bytes,
+    ) -> _InStreamErrorKind:
+        self._log_upstream_error(
+            url=url,
+            status_code=status_code,
+            response_headers={"x-dressage-in-stream-error": "1"},
+            response_body=error_body,
+            retried=False,
+        )
+        context_overflow = False
+        if snapshot is not None and snapshot.scope is not None:
+            context_overflow = await self._record_context_overflow_error(
+                snapshot.scope,
+                status_code=status_code,
+                response_body=error_body,
+            )
+            if await self._record_rollout_invalidated_error(
+                snapshot.scope,
+                status_code=status_code,
+                response_body=error_body,
+            ):
+                return "rollout_invalidated"
+        await self._record_failed_upstream_error(
+            snapshot,
+            url=url,
+            status_code=status_code,
+            request_headers=request_headers,
+            request_body=request_body,
+            response_headers={},
+            response_body=error_body,
+        )
+        return "context_overflow" if context_overflow else "failed_upstream"
 
     async def _record_rollout_invalidated_error(
         self,
@@ -1590,7 +1903,10 @@ class RolloutLLMProxy:
             payload = json.loads(response_body.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError):
             return None
-        if not isinstance(payload, dict) or payload.get("error") != "context_overflow":
+        if (
+            not isinstance(payload, dict)
+            or (payload.get("code") or payload.get("error")) != "context_overflow"
+        ):
             return None
         return payload
 
@@ -1613,7 +1929,9 @@ class RolloutLLMProxy:
             candidate = detail
         else:
             candidate = payload
-        if candidate.get("error") not in DRESSAGE_ROLLOUT_INVALIDATED_ERRORS:
+        if (
+            candidate.get("code") or candidate.get("error")
+        ) not in DRESSAGE_ROLLOUT_INVALIDATED_ERRORS:
             return None
         return {str(key): value for key, value in candidate.items()}
 
@@ -1644,7 +1962,7 @@ class RolloutLLMProxy:
         )
 
     @staticmethod
-    def _synthetic_chat_completion_stream_response() -> StreamingResponse:
+    def _synthetic_chat_completion_chunk_bytes() -> bytes:
         payload = {
             "id": "chatcmpl-rollout-invalidated",
             "object": "chat.completion.chunk",
@@ -1658,9 +1976,12 @@ class RolloutLLMProxy:
                 }
             ],
         }
+        return f"data: {json.dumps(payload)}\n\n".encode("utf-8")
 
+    @staticmethod
+    def _synthetic_chat_completion_stream_response() -> StreamingResponse:
         async def _events():
-            yield f"data: {json.dumps(payload)}\n\n".encode("utf-8")
+            yield RolloutLLMProxy._synthetic_chat_completion_chunk_bytes()
             yield b"data: [DONE]\n\n"
 
         return StreamingResponse(
@@ -1815,6 +2136,11 @@ class RolloutLLMProxy:
         self,
         upstream_response: httpx.Response,
         original_request: dict[str, Any],
+        *,
+        on_in_stream_error: Callable[
+            [int, bytes],
+            Awaitable[_InStreamErrorKind],
+        ],
     ):
         response_id = "resp_proxy_stream"
         item_id = "msg_proxy_stream"
@@ -1840,6 +2166,9 @@ class RolloutLLMProxy:
         )
 
         async for payload_text in _iter_openai_sse_payloads(upstream_response):
+            if payload_text is None:
+                yield b": dressage-heartbeat\n\n"
+                continue
             if payload_text == "[DONE]":
                 break
             try:
@@ -1847,6 +2176,20 @@ class RolloutLLMProxy:
             except json.JSONDecodeError:
                 continue
             if not isinstance(chunk, dict):
+                continue
+            sniffed = self._in_stream_error_from_chunk(chunk)
+            if sniffed is not None:
+                error_kind = await on_in_stream_error(*sniffed)
+                if error_kind == "failed_upstream":
+                    status_code, error_body = sniffed
+                    yield _openai_response_sse(
+                        "error",
+                        self._openai_response_in_stream_error_payload(
+                            status_code=status_code,
+                            response_body=error_body,
+                        ),
+                    )
+                    return
                 continue
             if chunk.get("model"):
                 model = str(chunk["model"])
@@ -1982,10 +2325,21 @@ class RolloutLLMProxy:
             "usage": usage,
         }
 
-    async def _iter_anthropic_events_from_openai_stream(self, upstream_response: httpx.Response):
+    async def _iter_anthropic_events_from_openai_stream(
+        self,
+        upstream_response: httpx.Response,
+        *,
+        on_in_stream_error: Callable[
+            [int, bytes],
+            Awaitable[_InStreamErrorKind],
+        ],
+    ):
         state = _AnthropicStreamState()
         yield state.message_start(model="proxy-model")
         async for payload in _iter_openai_sse_payloads(upstream_response):
+            if payload is None:
+                yield _anthropic_sse("ping", {"type": "ping"})
+                continue
             if payload == "[DONE]":
                 break
             try:
@@ -1993,6 +2347,20 @@ class RolloutLLMProxy:
             except json.JSONDecodeError:
                 continue
             if not isinstance(chunk, dict):
+                continue
+            sniffed = self._in_stream_error_from_chunk(chunk)
+            if sniffed is not None:
+                error_kind = await on_in_stream_error(*sniffed)
+                if error_kind == "failed_upstream":
+                    status_code, error_body = sniffed
+                    yield _anthropic_sse(
+                        "error",
+                        self._anthropic_in_stream_error_payload(
+                            status_code=status_code,
+                            response_body=error_body,
+                        ),
+                    )
+                    return
                 continue
             if chunk.get("model"):
                 state.model = str(chunk["model"])
@@ -2048,17 +2416,10 @@ class RolloutLLMProxy:
         upstream_status_code: int,
         response_body: bytes,
     ) -> Response:
-        body_preview = RolloutLLMProxy._preview_bytes(response_body, limit=1000)
-        message = f"Upstream returned HTTP {upstream_status_code}"
-        if body_preview:
-            message = f"{message}: {body_preview}"
-        body = {
-            "type": "error",
-            "error": {
-                "type": "upstream_error",
-                "message": message,
-            },
-        }
+        body = RolloutLLMProxy._anthropic_upstream_error_payload(
+            upstream_status_code=upstream_status_code,
+            response_body=response_body,
+        )
         return Response(
             content=json.dumps(body, ensure_ascii=False).encode("utf-8"),
             status_code=400,
@@ -2066,7 +2427,45 @@ class RolloutLLMProxy:
         )
 
     @staticmethod
-    def _anthropic_error_response_from_bytes(*, status_code: int, response_body: bytes) -> Response:
+    def _anthropic_upstream_error_payload(
+        *,
+        upstream_status_code: int,
+        response_body: bytes,
+    ) -> dict[str, Any]:
+        body_preview = RolloutLLMProxy._preview_bytes(response_body, limit=1000)
+        message = f"Upstream returned HTTP {upstream_status_code}"
+        if body_preview:
+            message = f"{message}: {body_preview}"
+        return {
+            "type": "error",
+            "error": {
+                "type": "upstream_error",
+                "message": message,
+            },
+        }
+
+    @staticmethod
+    def _anthropic_error_response_from_bytes(
+        *,
+        status_code: int,
+        response_body: bytes,
+    ) -> Response:
+        body = RolloutLLMProxy._anthropic_error_payload_from_bytes(
+            status_code=status_code,
+            response_body=response_body,
+        )
+        return Response(
+            content=json.dumps(body, ensure_ascii=False).encode("utf-8"),
+            status_code=status_code,
+            media_type="application/json",
+        )
+
+    @staticmethod
+    def _anthropic_error_payload_from_bytes(
+        *,
+        status_code: int,
+        response_body: bytes,
+    ) -> dict[str, Any]:
         message = (
             RolloutLLMProxy._preview_bytes(response_body, limit=1000)
             if response_body
@@ -2084,18 +2483,54 @@ class RolloutLLMProxy:
                 error_type = str(raw_error.get("type") or raw_error.get("code") or error_type)
             elif payload.get("message") is not None:
                 message = str(payload.get("message"))
-        body = {
+                error_type = str(
+                    payload.get("type") or payload.get("code") or error_type
+                )
+        return {
             "type": "error",
             "error": {
                 "type": error_type,
                 "message": message,
             },
         }
-        return Response(
-            content=json.dumps(body, ensure_ascii=False).encode("utf-8"),
+
+    @staticmethod
+    def _anthropic_in_stream_error_payload(
+        *,
+        status_code: int,
+        response_body: bytes,
+    ) -> dict[str, Any]:
+        if 500 <= status_code < 600:
+            return RolloutLLMProxy._anthropic_upstream_error_payload(
+                upstream_status_code=status_code,
+                response_body=response_body,
+            )
+        return RolloutLLMProxy._anthropic_error_payload_from_bytes(
             status_code=status_code,
-            media_type="application/json",
+            response_body=response_body,
         )
+
+    @staticmethod
+    def _openai_response_in_stream_error_payload(
+        *,
+        status_code: int,
+        response_body: bytes,
+    ) -> dict[str, Any]:
+        message = f"Upstream returned HTTP {status_code}"
+        code = "upstream_error"
+        try:
+            payload = json.loads(response_body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload = {}
+        if isinstance(payload, dict):
+            message = str(payload.get("message") or message)
+            code = str(payload.get("code") or payload.get("error") or code)
+        return {
+            "type": "error",
+            "code": code,
+            "message": message,
+            "param": None,
+        }
 
     @staticmethod
     def _preview_bytes(body: bytes, *, limit: int) -> str:
@@ -2942,16 +3377,55 @@ def _openai_finish_reason_to_anthropic(value: Any) -> str:
 
 
 async def _iter_openai_sse_payloads(response: httpx.Response):
+    """Yield SSE data payloads; comment-only events yield ``None``."""
     buffer = ""
     async for chunk in response.aiter_text():
         buffer += chunk
-        while "\n\n" in buffer:
-            raw_event, buffer = buffer.split("\n\n", 1)
-            for payload in _payloads_from_sse_event(raw_event):
+        while True:
+            framed = _pop_sse_event_text(buffer)
+            if framed is None:
+                break
+            raw_event, _delimiter, buffer = framed
+            payloads = _payloads_from_sse_event(raw_event)
+            if not payloads and _is_sse_comment_event(raw_event):
+                yield None
+                continue
+            for payload in payloads:
                 yield payload
     if buffer.strip():
         for payload in _payloads_from_sse_event(buffer):
             yield payload
+
+
+def _pop_sse_event_bytes(buffer: bytes) -> tuple[bytes, bytes, bytes] | None:
+    candidates = [
+        (index, delimiter)
+        for delimiter in (b"\r\n\r\n", b"\n\n", b"\r\r")
+        if (index := buffer.find(delimiter)) >= 0
+    ]
+    if not candidates:
+        return None
+    index, delimiter = min(candidates, key=lambda candidate: candidate[0])
+    end = index + len(delimiter)
+    return buffer[:index], delimiter, buffer[end:]
+
+
+def _pop_sse_event_text(buffer: str) -> tuple[str, str, str] | None:
+    candidates = [
+        (index, delimiter)
+        for delimiter in ("\r\n\r\n", "\n\n", "\r\r")
+        if (index := buffer.find(delimiter)) >= 0
+    ]
+    if not candidates:
+        return None
+    index, delimiter = min(candidates, key=lambda candidate: candidate[0])
+    end = index + len(delimiter)
+    return buffer[:index], delimiter, buffer[end:]
+
+
+def _is_sse_comment_event(raw_event: str) -> bool:
+    lines = [line for line in raw_event.splitlines() if line.strip()]
+    return bool(lines) and all(line.startswith(":") for line in lines)
 
 
 def _payloads_from_sse_event(raw_event: str) -> list[str]:

--- a/dressage/proxy/generation_controller.py
+++ b/dressage/proxy/generation_controller.py
@@ -247,6 +247,33 @@ class GenerationController:
                     logprob_start_len=chunk_logprob_start_len,
                 )
                 forced_preempted = active.abort_succeeded
+            except asyncio.CancelledError:
+                # A disconnected stream cancels its response producer. Abort
+                # the model request before removing it from the active set.
+                active.state = "preempting"
+                try:
+                    await asyncio.shield(
+                        self._abort_active_with_timeout(
+                            active,
+                            timeout_seconds=5.0,
+                        )
+                    )
+                except BaseException as abort_exc:
+                    active.abort_succeeded = False
+                    active.abort_error = repr(abort_exc)
+                    logger.warning(
+                        "failed to abort cancelled SGLang request rid=%s "
+                        "session_id=%s error=%s",
+                        active.request_id,
+                        active.session_id,
+                        abort_exc,
+                    )
+                finally:
+                    async with self._pause_lock:
+                        self._active.pop(active.request_id, None)
+                        active.state = "quiesced"
+                        active.quiesced_event.set()
+                raise
             except Exception as exc:
                 if self._shutting_down:
                     async with self._pause_lock:

--- a/dressage/proxy/server.py
+++ b/dressage/proxy/server.py
@@ -7,17 +7,17 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import os
 import time
 import uuid
 from contextlib import asynccontextmanager
-
-import httpx
 from typing import Any, Literal
 
+import httpx
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from transformers import AutoTokenizer
 
 from dressage.config import (
@@ -55,6 +55,52 @@ logger = logging.getLogger(__name__)
 _INPUT_TOKEN_VERSION = "-1"
 _DEFAULT_TOOL_CALL_PARSER = object()
 _NON_REAL_TOKEN_VERSIONS = {"", "-1", "unknown", "none"}
+_DEFAULT_STREAM_HEARTBEAT_INTERVAL_SECONDS = 15.0
+_SSE_HEARTBEAT = ": dressage-heartbeat\n\n"
+_SSE_RESPONSE_HEADERS = {
+    "Cache-Control": "no-cache, no-transform",
+    "X-Accel-Buffering": "no",
+}
+
+
+def _response_json_payload(response: Response) -> Any:
+    body = bytes(response.body)
+    try:
+        return json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return {"message": body.decode("utf-8", "replace")}
+
+
+def _stream_error_chunk(status_code: int, payload: Any) -> str:
+    """Render an in-stream SSE error event.
+
+    Once heartbeat streaming has sent the response headers, failures can no
+    longer change the HTTP status code, so the payload is normalized into a
+    terminal error event that retains its details and intended status code.
+    """
+
+    error = dict(payload) if isinstance(payload, dict) else {"message": str(payload)}
+    raw_code = error.get("code") or error.get("error")
+    code = raw_code if isinstance(raw_code, str) and raw_code else "http_error"
+    raw_message = error.get("message") or error.get("detail")
+    message = (
+        raw_message
+        if isinstance(raw_message, str) and raw_message
+        else f"Dressage proxy error: {code}"
+    )
+    error.pop("error", None)
+    error["type"] = "dressage_proxy_error"
+    error["code"] = code
+    error["message"] = message
+    error["status_code"] = status_code
+    return f"data: {json.dumps({'error': error})}\n\n"
+
+
+def _consume_task_exception(task: asyncio.Task[Any]) -> None:
+    """Retrieve a detached pipeline exception to avoid an asyncio warning."""
+
+    if not task.cancelled():
+        task.exception()
 TokenBuildMode = Literal["tito", "snapshot"]
 SegmentView = Literal["lineage", "timeline"]
 
@@ -80,6 +126,18 @@ def _non_negative_int(value: str) -> int:
         raise argparse.ArgumentTypeError("must be an integer") from exc
     if parsed < 0:
         raise argparse.ArgumentTypeError("must be greater than or equal to 0")
+    return parsed
+
+
+def _non_negative_finite_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number") from exc
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError(
+            "must be a finite number greater than or equal to 0"
+        )
     return parsed
 
 
@@ -562,11 +620,22 @@ def create_app(
     use_rollout_routing_replay: bool = False,
     partial_rollout: bool = False,
     max_partial_rollout_preempts: int | None = None,
+    stream_heartbeat_interval_seconds: float = (
+        _DEFAULT_STREAM_HEARTBEAT_INTERVAL_SECONDS
+    ),
 ) -> FastAPI:
     """Create the Dressage proxy FastAPI app."""
 
     if context_window is not None and context_window <= 0:
         raise ValueError("context_window must be greater than 0 when provided")
+    if (
+        not math.isfinite(stream_heartbeat_interval_seconds)
+        or stream_heartbeat_interval_seconds < 0
+    ):
+        raise ValueError(
+            "stream_heartbeat_interval_seconds must be a finite number "
+            "greater than or equal to 0"
+        )
     if max_output_tokens is not None and max_output_tokens <= 0:
         raise ValueError("max_output_tokens must be greater than 0")
     if max_partial_rollout_preempts is not None and max_partial_rollout_preempts < 0:
@@ -1420,20 +1489,20 @@ def create_app(
                 }
             )
 
-    @app.post("/v1/chat/completions")
-    async def chat_completions(request: Request):
-        _check_auth(request)
-        body = await request.json()
+    async def _chat_completions_pipeline(
+        request: Request, body: dict[str, Any]
+    ) -> Response:
+        """Run one full generate-and-record step and build its HTTP response."""
         messages: list[dict] = body.get("messages", [])
         model = body.get("model", "proxy-model")
         stream = bool(body.get("stream", False))
-        tools = body.get("tools")
         stream_options = body.get("stream_options")
         if not isinstance(stream_options, dict):
             stream_options = {}
         # Dressage defaults usage on for opencode compatibility; set
         # stream_options.include_usage=false to opt out.
         include_usage = stream_options.get("include_usage", True) is not False
+        tools = body.get("tools")
 
         session_id, instance_id, turn_id = _runtime_ids_from_request(request, body)
         try:
@@ -1938,6 +2007,7 @@ def create_app(
                     include_usage,
                 ),
                 media_type="text/event-stream",
+                headers=_SSE_RESPONSE_HEADERS,
             )
 
         return JSONResponse(
@@ -1951,6 +2021,94 @@ def create_app(
                 completion_tokens=public_completion_tokens,
                 response_id=response_id,
             )
+        )
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request):
+        _check_auth(request)
+        body = await request.json()
+        stream = bool(body.get("stream", False))
+
+        if not stream or stream_heartbeat_interval_seconds <= 0:
+            return await _chat_completions_pipeline(request, body)
+
+        # Preserve the original HTTP status for operations that finish before
+        # the first configured heartbeat.
+        task = asyncio.create_task(_chat_completions_pipeline(request, body))
+        task.add_done_callback(_consume_task_exception)
+        try:
+            done, _ = await asyncio.wait(
+                {task},
+                timeout=stream_heartbeat_interval_seconds,
+            )
+        except asyncio.CancelledError:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise
+        if done:
+            return task.result()
+
+        async def _heartbeat_stream():
+            try:
+                while True:
+                    if task.done():
+                        break
+                    yield _SSE_HEARTBEAT
+                    finished, _ = await asyncio.wait(
+                        {task},
+                        timeout=stream_heartbeat_interval_seconds,
+                    )
+                    if finished:
+                        break
+                try:
+                    result = task.result()
+                except HTTPException as exc:
+                    yield _stream_error_chunk(exc.status_code, exc.detail)
+                    yield "data: [DONE]\n\n"
+                    return
+                except Exception:
+                    logger.exception("chat completion failed during heartbeat streaming")
+                    yield _stream_error_chunk(
+                        500,
+                        {
+                            "code": "internal_error",
+                            "message": "Internal proxy error.",
+                        },
+                    )
+                    yield "data: [DONE]\n\n"
+                    return
+                if not 200 <= result.status_code < 300:
+                    yield _stream_error_chunk(
+                        result.status_code, _response_json_payload(result)
+                    )
+                    yield "data: [DONE]\n\n"
+                    return
+                if not isinstance(result, StreamingResponse):
+                    logger.error(
+                        "chat completion pipeline returned a non-streaming "
+                        "success response after heartbeat streaming started"
+                    )
+                    yield _stream_error_chunk(
+                        500,
+                        {
+                            "code": "internal_error",
+                            "message": "Internal proxy error.",
+                        },
+                    )
+                    yield "data: [DONE]\n\n"
+                    return
+                async for chunk in result.body_iterator:
+                    yield chunk
+            finally:
+                if not task.done():
+                    task.cancel()
+                    await asyncio.gather(task, return_exceptions=True)
+                    logger.info("chat completion client disconnected; cancelled generation")
+
+        return StreamingResponse(
+            _heartbeat_stream(),
+            media_type="text/event-stream",
+            headers=_SSE_RESPONSE_HEADERS,
         )
 
     @app.post("/session/finalize")
@@ -2245,6 +2403,9 @@ def create_app(
                 "use_rollout_routing_replay": use_rollout_routing_replay,
                 "partial_rollout": partial_rollout,
                 "max_partial_rollout_preempts": max_partial_rollout_preempts,
+                "stream_heartbeat_interval_seconds": (
+                    stream_heartbeat_interval_seconds
+                ),
             },
         }
 
@@ -2352,6 +2513,16 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Maximum model weight version switches allowed for one partial-rollout session.",
     )
+    parser.add_argument(
+        "--stream-heartbeat-interval-seconds",
+        type=_non_negative_finite_float,
+        default=_DEFAULT_STREAM_HEARTBEAT_INTERVAL_SECONDS,
+        help=(
+            "Seconds between SSE comment heartbeats for stream=true requests "
+            "while generation is still running. 0 disables heartbeats and "
+            "keeps the legacy respond-after-completion behavior."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -2384,6 +2555,7 @@ def main() -> None:
         use_rollout_routing_replay=args.use_rollout_routing_replay,
         partial_rollout=args.dressage_partial_rollout,
         max_partial_rollout_preempts=args.max_partial_rollout_preempts,
+        stream_heartbeat_interval_seconds=args.stream_heartbeat_interval_seconds,
     )
     uvicorn.run(app, host=args.host, port=args.port)
 

--- a/tests/blackbox_server/test_async_turns.py
+++ b/tests/blackbox_server/test_async_turns.py
@@ -106,6 +106,58 @@ class SlowAdapter(FakeAdapter):
         )
 
 
+def test_repeated_cancellation_waits_for_backend_child_cleanup(
+    tmp_path: Path,
+) -> None:
+    async def run_test() -> None:
+        server = BlackboxServer(
+            BlackboxServerConfig(runtime_root=str(tmp_path / "runtime"))
+        )
+        backend_started = asyncio.Event()
+        cleanup_started = asyncio.Event()
+        cleanup_release = asyncio.Event()
+        cleanup_finished = asyncio.Event()
+        cleanup_interrupted = asyncio.Event()
+
+        async def backend_call() -> None:
+            backend_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cleanup_started.set()
+                try:
+                    await cleanup_release.wait()
+                except asyncio.CancelledError:
+                    cleanup_interrupted.set()
+                    raise
+                cleanup_finished.set()
+                raise
+
+        waiter = asyncio.create_task(
+            server._wait_for_backend_call_excluding_pause(
+                backend_call(),
+                timeout=30.0,
+            )
+        )
+        await backend_started.wait()
+        waiter.cancel()
+        await cleanup_started.wait()
+        waiter.cancel()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert not waiter.done()
+        assert not cleanup_finished.is_set()
+        assert not cleanup_interrupted.is_set()
+
+        cleanup_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        assert cleanup_finished.is_set()
+
+    asyncio.run(run_test())
+
+
 def make_client(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/blackbox_server/test_claude_code_adapter.py
+++ b/tests/blackbox_server/test_claude_code_adapter.py
@@ -4,11 +4,17 @@ import asyncio
 import json
 import sys
 from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 
 import pytest
 
 import blackbox_server.adapters.claude_code as claude_code_module
-from blackbox_server.adapters.base import BackendProtocolError, BackendTransportError
+from blackbox_server.adapters.base import (
+    BackendContextOverflowError,
+    BackendProtocolError,
+    BackendTransportError,
+)
 from blackbox_server.adapters.claude_code import (
     ClaudeCodeAdapter,
     ClaudeCodeBackendOptions,
@@ -22,7 +28,16 @@ from blackbox_server.adapters.claude_code import (
     convert_claude_code_stream_events,
 )
 from blackbox_server.config import BlackboxServerConfig
-from blackbox_server.core.models import BindingContext, BindingInfo, TurnContext, utcnow
+from blackbox_server.core.models import (
+    BindingContext,
+    BindingInfo,
+    Message,
+    SessionContext,
+    SessionState,
+    TurnContext,
+    TurnUsage,
+    utcnow,
+)
 
 EXPECTED_CLAUDE_CODE_PERMISSION_ALLOW = [
     "Bash(*)",
@@ -464,8 +479,17 @@ def test_claude_code_stream_error_summary_extracts_nested_error_fields() -> None
     assert "transport closed" in summary
 
 
-def test_claude_code_adapter_appends_failed_upstream_payload_path() -> None:
+def test_adapter_proxy_failure_appends_failed_upstream_payload_paths() -> None:
     class FakeProxy:
+        async def drain_turn(self, timeout: float | None = None) -> None:
+            assert timeout == 2.0
+
+        async def consume_context_overflow_error(self) -> None:
+            return None
+
+        async def consume_rollout_invalidated_error(self) -> None:
+            return None
+
         async def consume_failed_upstream_error(self) -> dict[str, object]:
             return {
                 "message": "Upstream returned HTTP 500: Internal Server Error",
@@ -475,14 +499,229 @@ def test_claude_code_adapter_appends_failed_upstream_payload_path() -> None:
 
     async def run_test() -> None:
         adapter = ClaudeCodeAdapter()
-        adapter._proxy = FakeProxy()  # type: ignore[assignment]
+        original_error = BackendTransportError("claude_code exited with code 1")
         with pytest.raises(BackendTransportError) as exc_info:
-            await adapter._raise_with_proxy_failed_upstream(BackendTransportError("claude_code exited with code 1"))
+            await adapter._drain_and_raise_proxy_failure(
+                FakeProxy(),
+                original_error=original_error,
+                drain_timeout=2.0,
+            )
         message = str(exc_info.value)
         assert "claude_code exited with code 1" in message
         assert "Internal Server Error" in message
         assert "failed upstream payload: /tmp/runtime/logs/upstream_request.turn-001.0.json" in message
         assert "failed upstream response: /tmp/runtime/logs/upstream_response.turn-001.0.json" in message
+        assert exc_info.value.__cause__ is original_error
+
+    asyncio.run(run_test())
+
+
+def test_adapter_proxy_failure_prefers_context_overflow_marker() -> None:
+    calls: list[str] = []
+
+    class FakeProxy:
+        async def drain_turn(self, timeout: float | None = None) -> None:
+            calls.append("drain")
+
+        async def consume_context_overflow_error(self) -> dict[str, object]:
+            calls.append("context_overflow")
+            return {
+                "type": "dressage_proxy_error",
+                "code": "context_overflow",
+                "message": "Prompt plus completion exceeds the context window.",
+                "details": {
+                    "context_window": 4096,
+                    "input_tokens": 4000,
+                    "max_tokens": 512,
+                },
+            }
+
+        async def consume_rollout_invalidated_error(self) -> dict[str, object]:
+            calls.append("rollout_invalidated")
+            return {"code": "generation_preempted"}
+
+        async def consume_failed_upstream_error(self) -> dict[str, object]:
+            calls.append("failed_upstream")
+            return {"message": "Upstream returned HTTP 413"}
+
+    async def run_test() -> None:
+        adapter = ClaudeCodeAdapter()
+        original_error = BackendProtocolError("invalid backend response")
+        with pytest.raises(BackendContextOverflowError) as exc_info:
+            await adapter._drain_and_raise_proxy_failure(
+                FakeProxy(),
+                original_error=original_error,
+                drain_timeout=2.0,
+            )
+
+        assert exc_info.value.context_window == 4096
+        assert exc_info.value.__cause__ is original_error
+        assert calls == ["drain", "context_overflow"]
+
+    asyncio.run(run_test())
+
+
+def test_adapter_proxy_failure_prefers_invalidated_over_failed_upstream() -> None:
+    calls: list[str] = []
+
+    class FakeProxy:
+        async def drain_turn(self, timeout: float | None = None) -> None:
+            calls.append("drain")
+
+        async def consume_context_overflow_error(self) -> None:
+            calls.append("context_overflow")
+            return None
+
+        async def consume_rollout_invalidated_error(self) -> dict[str, object]:
+            calls.append("rollout_invalidated")
+            return {
+                "code": "generation_preempted",
+                "message": "Generation was preempted.",
+            }
+
+        async def consume_failed_upstream_error(self) -> dict[str, object]:
+            calls.append("failed_upstream")
+            return {"message": "Upstream returned HTTP 502"}
+
+    async def run_test() -> None:
+        adapter = ClaudeCodeAdapter()
+        original_error = BackendProtocolError("invalid backend response")
+        with pytest.raises(
+            BackendTransportError,
+            match="generation_preempted",
+        ) as exc_info:
+            await adapter._drain_and_raise_proxy_failure(
+                FakeProxy(),
+                original_error=original_error,
+                drain_timeout=2.0,
+            )
+
+        assert exc_info.value.__cause__ is original_error
+        assert calls == ["drain", "context_overflow", "rollout_invalidated"]
+
+    asyncio.run(run_test())
+
+
+def test_proxy_wait_cancellation_cancels_backend_task() -> None:
+    backend_started = asyncio.Event()
+    backend_cancelled = asyncio.Event()
+
+    class FakeProxy:
+        async def wait_for_max_steps_error(
+            self,
+            timeout: float | None = None,
+        ) -> None:
+            await asyncio.Event().wait()
+
+        async def consume_max_steps_error(self) -> None:
+            return None
+
+    async def backend() -> None:
+        backend_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            backend_cancelled.set()
+            raise
+
+    async def run_test() -> None:
+        adapter = ClaudeCodeAdapter()
+        backend_task = asyncio.create_task(backend())
+        waiter = asyncio.create_task(
+            adapter._await_backend_task_or_proxy_max_steps(
+                backend_task,
+                session_context=None,  # type: ignore[arg-type]
+                proxy=FakeProxy(),
+            )
+        )
+        await backend_started.wait()
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+        assert backend_task.cancelled()
+        assert backend_cancelled.is_set()
+
+    asyncio.run(run_test())
+
+
+def test_claude_code_success_path_surfaces_proxy_failed_upstream(
+    tmp_path: Path,
+) -> None:
+    class FakeProxy:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, Any]] = []
+
+        async def open_turn(
+            self,
+            turn_id: str,
+            backend_session_id: str | None = None,
+        ) -> None:
+            self.calls.append(("open", (turn_id, backend_session_id)))
+
+        async def drain_turn(self, timeout: float | None = None) -> None:
+            self.calls.append(("drain", timeout))
+
+        async def consume_context_overflow_error(self) -> None:
+            self.calls.append(("consume_context_overflow_error", None))
+            return None
+
+        async def consume_rollout_invalidated_error(self) -> None:
+            self.calls.append(("consume_rollout_invalidated_error", None))
+            return None
+
+        async def consume_failed_upstream_error(self) -> dict[str, object]:
+            self.calls.append(("consume_failed_upstream_error", None))
+            return {"message": "Upstream returned HTTP 503: unavailable"}
+
+        async def clear_turn(self) -> None:
+            self.calls.append(("clear", None))
+
+    async def run_test() -> None:
+        adapter = ClaudeCodeAdapter()
+        adapter._binding_context = _make_binding_context(tmp_path)
+        adapter._proxy = FakeProxy()  # type: ignore[assignment]
+        session = SessionContext(
+            session_id="test-session",
+            state=SessionState.ACTIVE,
+            blackbox_type="claude_code",
+            backend_session_id="claude-session-1",
+            router_base_url="http://127.0.0.1:30000/v1",
+            created_at=utcnow(),
+            updated_at=utcnow(),
+        )
+        turn = TurnContext(
+            turn_id="turn-1",
+            request_fingerprint="fp-turn-1",
+            deadline_seconds=30.0,
+        )
+
+        with (
+            patch.object(adapter, "health", return_value=True),
+            patch.object(
+                adapter,
+                "_run_claude_turn",
+                return_value=([], [], TurnUsage()),
+            ),
+        ):
+            with pytest.raises(BackendTransportError, match="Upstream returned HTTP 503"):
+                await adapter.send_message(
+                    session,
+                    turn,
+                    [Message(role="user", content="hello")],
+                )
+
+        assert adapter._proxy.calls[0] == (
+            "open",
+            ("turn-1", "claude-session-1"),
+        )
+        assert adapter._proxy.calls[1][0] == "drain"
+        assert adapter._proxy.calls[2:] == [
+            ("consume_context_overflow_error", None),
+            ("consume_rollout_invalidated_error", None),
+            ("consume_failed_upstream_error", None),
+            ("clear", None),
+        ]
 
     asyncio.run(run_test())
 

--- a/tests/blackbox_server/test_codex_adapter.py
+++ b/tests/blackbox_server/test_codex_adapter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -12,6 +14,7 @@ from blackbox_server.adapters.codex import (
     CodexAdapter,
     CodexBackendOptions,
     CodexConfigCompiler,
+    CodexRunResult,
     CodexSessionState,
     _CODEX_STDOUT_STREAM_LIMIT,
     _build_codex_exit_error_message,
@@ -21,9 +24,11 @@ from blackbox_server.config import BlackboxServerConfig
 from blackbox_server.core.models import (
     BindingContext,
     BindingInfo,
+    Message,
     SessionContext,
     SessionState,
     TurnContext,
+    TurnUsage,
     utcnow,
 )
 
@@ -805,6 +810,95 @@ def test_run_codex_turn_rejects_invalid_jsonl_and_terminates_process(
             await adapter.shutdown()
 
         assert killed_process_groups
+
+    asyncio.run(run_test())
+
+
+def test_codex_success_path_surfaces_proxy_failed_upstream(
+    tmp_path: Path,
+) -> None:
+    class FakeProxy:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, Any]] = []
+
+        async def open_turn(
+            self,
+            turn_id: str,
+            backend_session_id: str | None = None,
+        ) -> None:
+            self.calls.append(("open", (turn_id, backend_session_id)))
+
+        async def drain_turn(self, timeout: float | None = None) -> None:
+            self.calls.append(("drain", timeout))
+
+        async def consume_context_overflow_error(self) -> None:
+            self.calls.append(("consume_context_overflow_error", None))
+            return None
+
+        async def consume_rollout_invalidated_error(self) -> None:
+            self.calls.append(("consume_rollout_invalidated_error", None))
+            return None
+
+        async def consume_failed_upstream_error(self) -> dict[str, object]:
+            self.calls.append(("consume_failed_upstream_error", None))
+            return {"message": "Upstream returned HTTP 503: unavailable"}
+
+        async def clear_turn(self) -> None:
+            self.calls.append(("clear", None))
+
+    async def run_test() -> None:
+        adapter = CodexAdapter()
+        adapter._binding_context = _make_binding_context(tmp_path)
+        adapter._proxy = FakeProxy()  # type: ignore[assignment]
+        session = SessionContext(
+            session_id="test-session",
+            state=SessionState.ACTIVE,
+            blackbox_type="codex",
+            backend_session_id="codex-session-1",
+            router_base_url="http://127.0.0.1:30000/v1",
+            created_at=utcnow(),
+            updated_at=utcnow(),
+        )
+        turn = TurnContext(
+            turn_id="turn-1",
+            request_fingerprint="fp-turn-1",
+            deadline_seconds=30.0,
+        )
+
+        with (
+            patch.object(adapter, "health", return_value=True),
+            patch.object(
+                adapter,
+                "_run_codex_turn",
+                return_value=CodexRunResult(
+                    outputs=[],
+                    trace_events=[],
+                    usage=TurnUsage(),
+                    backend_session_id=None,
+                ),
+            ),
+        ):
+            with pytest.raises(
+                BackendTransportError,
+                match="Upstream returned HTTP 503",
+            ):
+                await adapter.send_message(
+                    session,
+                    turn,
+                    [Message(role="user", content="hello")],
+                )
+
+        assert adapter._proxy.calls[0] == (
+            "open",
+            ("turn-1", "codex-session-1"),
+        )
+        assert adapter._proxy.calls[1][0] == "drain"
+        assert adapter._proxy.calls[2:] == [
+            ("consume_context_overflow_error", None),
+            ("consume_rollout_invalidated_error", None),
+            ("consume_failed_upstream_error", None),
+            ("clear", None),
+        ]
 
     asyncio.run(run_test())
 

--- a/tests/blackbox_server/test_openclaw_adapter.py
+++ b/tests/blackbox_server/test_openclaw_adapter.py
@@ -97,6 +97,15 @@ class FakeProxy:
         self.calls.append(("clear", None))
 
 
+class FailedUpstreamProxy(FakeProxy):
+    async def consume_failed_upstream_error(self) -> dict[str, Any]:
+        self.calls.append(("consume_failed_upstream_error", None))
+        return {
+            "message": "Upstream returned HTTP 503: unavailable",
+            "response_path": "/tmp/upstream-response.json",
+        }
+
+
 def _make_binding_context(
     tmp_path: Path,
     *,
@@ -659,8 +668,7 @@ def test_send_message_posts_chat_completion_payload_and_headers(tmp_path: Path) 
     assert isinstance(adapter._proxy.calls[1][1], float)
     assert adapter._proxy.calls[2] == ("consume_context_overflow_error", None)
     assert adapter._proxy.calls[3] == ("consume_rollout_invalidated_error", None)
-    assert adapter._proxy.calls[4] == ("drain", None)
-    assert adapter._proxy.calls[5] == ("clear", None)
+    assert adapter._proxy.calls[4] == ("clear", None)
 
 
 def test_send_message_raises_proxy_rollout_invalidated_error(tmp_path: Path) -> None:
@@ -709,6 +717,46 @@ def test_send_message_raises_proxy_rollout_invalidated_error(tmp_path: Path) -> 
 
     assert ("consume_rollout_invalidated_error", None) in adapter._proxy.calls
     assert ("clear", None) in adapter._proxy.calls
+
+
+def test_send_message_preserves_proxy_failure_when_backend_raises(
+    tmp_path: Path,
+) -> None:
+    adapter = OpenClawAdapter()
+    adapter._binding_context = _make_binding_context(tmp_path)
+    adapter._options = _minimal_options()
+    adapter._proxy = FailedUpstreamProxy()
+
+    async def run_test() -> None:
+        with (
+            patch.object(adapter, "health", return_value=True),
+            patch.object(
+                adapter,
+                "_post_chat_completions",
+                side_effect=BackendProtocolError("invalid streamed response"),
+            ),
+        ):
+            with pytest.raises(BackendTransportError) as exc_info:
+                await adapter.send_message(
+                    _make_session_context(),
+                    _make_turn_context("turn-1"),
+                    [Message(role="user", content="hello")],
+                )
+
+        message = str(exc_info.value)
+        assert "invalid streamed response" in message
+        assert "Upstream returned HTTP 503" in message
+        assert "failed upstream response: /tmp/upstream-response.json" in message
+
+    asyncio.run(run_test())
+
+    calls = adapter._proxy.calls
+    assert calls[0] == ("open", ("turn-1", "bbs:inst-001:sess-001"))
+    assert calls[1] == ("drain", 2.0)
+    assert calls[2] == ("consume_context_overflow_error", None)
+    assert calls[3] == ("consume_rollout_invalidated_error", None)
+    assert calls[4] == ("consume_failed_upstream_error", None)
+    assert calls[5] == ("clear", None)
 
 
 def test_send_message_cancels_openclaw_chat_on_proxy_max_steps(tmp_path: Path) -> None:

--- a/tests/blackbox_server/test_opencode_adapter.py
+++ b/tests/blackbox_server/test_opencode_adapter.py
@@ -262,6 +262,23 @@ class FakeProxy:
         self.calls.append(("clear", None))
 
 
+class FailedUpstreamProxy(FakeProxy):
+    async def consume_context_overflow_error(self) -> None:
+        self.calls.append(("consume_context_overflow_error", None))
+        return None
+
+    async def consume_rollout_invalidated_error(self) -> None:
+        self.calls.append(("consume_rollout_invalidated_error", None))
+        return None
+
+    async def consume_failed_upstream_error(self) -> dict[str, Any]:
+        self.calls.append(("consume_failed_upstream_error", None))
+        return {
+            "message": "Upstream returned HTTP 503: unavailable",
+            "request_path": "/tmp/upstream-request.json",
+        }
+
+
 def _make_binding_context(
     *,
     system_prompt: RuntimeSystemPrompt | None = None,
@@ -352,8 +369,7 @@ def test_send_message_drains_and_clears_proxy_scope():
         assert adapter._proxy.calls[1] == ("update", "oc-session-1")
         assert adapter._proxy.calls[2][0] == "drain"
         assert isinstance(adapter._proxy.calls[2][1], float)
-        assert adapter._proxy.calls[3] == ("drain", None)
-        assert adapter._proxy.calls[4] == ("clear", None)
+        assert adapter._proxy.calls[3] == ("clear", None)
 
     asyncio.run(run_test())
 
@@ -382,6 +398,50 @@ def test_send_message_best_effort_drains_proxy_on_failure():
         ]
 
     asyncio.run(run_test())
+
+
+def test_send_message_preserves_proxy_failure_when_backend_raises():
+    adapter = OpencodeAdapter()
+    adapter._proxy = FailedUpstreamProxy()
+    session = _make_session_context(backend_session_id=None)
+
+    async def run_test() -> None:
+        with (
+            patch.object(adapter, "health", return_value=True),
+            patch.object(
+                adapter,
+                "_ensure_backend_session",
+                return_value="oc-session-1",
+            ),
+            patch.object(
+                adapter,
+                "_post_message_with_connect_retry",
+                side_effect=BackendProtocolError("invalid streamed response"),
+            ),
+        ):
+            with pytest.raises(BackendTransportError) as exc_info:
+                await adapter.send_message(
+                    session,
+                    _make_turn_context("turn-1"),
+                    [Message(role="user", content="hello")],
+                )
+
+        message = str(exc_info.value)
+        assert "invalid streamed response" in message
+        assert "Upstream returned HTTP 503" in message
+        assert "failed upstream payload: /tmp/upstream-request.json" in message
+
+    asyncio.run(run_test())
+
+    assert adapter._proxy.calls == [
+        ("open", ("turn-1", None)),
+        ("update", "oc-session-1"),
+        ("drain", 2.0),
+        ("consume_context_overflow_error", None),
+        ("consume_rollout_invalidated_error", None),
+        ("consume_failed_upstream_error", None),
+        ("clear", None),
+    ]
 
 
 def test_send_message_aborts_pending_opencode_post_on_proxy_max_steps():

--- a/tests/blackbox_server/test_rollout_llm_proxy.py
+++ b/tests/blackbox_server/test_rollout_llm_proxy.py
@@ -24,6 +24,25 @@ class MockAsyncByteStream(httpx.AsyncByteStream):
         return None
 
 
+class BlockingAsyncByteStream(httpx.AsyncByteStream):
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.closed = asyncio.Event()
+
+    async def __aiter__(self):
+        self.started.set()
+        await asyncio.Event().wait()
+        yield b""
+
+    async def aclose(self) -> None:
+        self.closed.set()
+
+
+class RaisingCloseAsyncByteStream(MockAsyncByteStream):
+    async def aclose(self) -> None:
+        raise RuntimeError("upstream close failed")
+
+
 def _make_proxy(
     sticky_header_name: str = "X-SMG-Routing-Key",
     *,
@@ -396,6 +415,215 @@ def test_rollout_proxy_scopes_increment_steps_and_inject_turn_header():
         assert headers["X-Turn-Id"] == "turn-001"
 
     asyncio.run(run_test())
+
+
+def test_rollout_proxy_successful_later_attempt_clears_retryable_upstream_error():
+    proxy = _make_proxy(max_steps=2)
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        if request_count == 1:
+            return httpx.Response(
+                503,
+                json={
+                    "error": {
+                        "code": "sglang_upstream_unavailable",
+                        "message": "router unavailable",
+                    }
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp-1",
+                "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            },
+        )
+
+    body = {
+        "model": "agent-model",
+        "messages": [{"role": "user", "content": "same"}],
+        "stream": False,
+    }
+
+    async def run_test() -> tuple[httpx.Response, httpx.Response, dict[str, Any] | None]:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            failed = await client.post("/v1/chat/completions", json=body)
+            recovered = await client.post("/v1/chat/completions", json=body)
+        remaining_error = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+        return failed, recovered, remaining_error
+
+    failed, recovered, remaining_error = asyncio.run(run_test())
+
+    assert failed.status_code == 503
+    assert recovered.status_code == 200
+    assert request_count == 2
+    assert remaining_error is None
+
+
+def test_rollout_proxy_later_step_success_ignores_delayed_retryable_error():
+    proxy = _make_proxy(max_steps=2)
+    first_request_started = asyncio.Event()
+    release_first_request = asyncio.Event()
+    request_count = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        if request_count == 1:
+            first_request_started.set()
+            await release_first_request.wait()
+            return httpx.Response(503, text="delayed temporary failure")
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp-2",
+                "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            },
+        )
+
+    async def run_test() -> dict[str, Any] | None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            delayed_failure = asyncio.create_task(
+                client.post(
+                    "/v1/chat/completions",
+                    json={"model": "agent-model", "messages": []},
+                )
+            )
+            await first_request_started.wait()
+            recovered = await client.post(
+                "/v1/chat/completions",
+                json={"model": "agent-model", "messages": []},
+            )
+            release_first_request.set()
+            failed = await delayed_failure
+        remaining_error = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        assert recovered.status_code == 200
+        assert failed.status_code == 503
+        return remaining_error
+
+    assert asyncio.run(run_test()) is None
+
+
+def test_rollout_proxy_delayed_retryable_error_does_not_hide_terminal_error():
+    proxy = _make_proxy(max_steps=3)
+    first_request_started = asyncio.Event()
+    release_first_request = asyncio.Event()
+    request_count = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        if request_count == 1:
+            first_request_started.set()
+            await release_first_request.wait()
+            return httpx.Response(503, text="delayed temporary failure")
+        if request_count == 2:
+            return httpx.Response(400, text="terminal failure")
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp-3",
+                "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            },
+        )
+
+    async def run_test() -> dict[str, Any] | None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            delayed_retryable = asyncio.create_task(
+                client.post(
+                    "/v1/chat/completions",
+                    json={"model": "agent-model", "messages": []},
+                )
+            )
+            await first_request_started.wait()
+            terminal = await client.post(
+                "/v1/chat/completions",
+                json={"model": "agent-model", "messages": []},
+            )
+            release_first_request.set()
+            retryable = await delayed_retryable
+            recovered = await client.post(
+                "/v1/chat/completions",
+                json={"model": "agent-model", "messages": []},
+            )
+        remaining_error = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        assert terminal.status_code == 400
+        assert retryable.status_code == 503
+        assert recovered.status_code == 200
+        return remaining_error
+
+    remaining_error = asyncio.run(run_test())
+    assert remaining_error is not None
+    assert remaining_error["status_code"] == 400
+    assert remaining_error["step"] == 1
+
+
+def test_rollout_proxy_terminal_retry_error_replaces_retryable_error():
+    proxy = _make_proxy(max_steps=2)
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        status_code = 503 if request_count == 1 else 500
+        return httpx.Response(
+            status_code,
+            json={"error": {"message": f"upstream {status_code}"}},
+        )
+
+    body = {
+        "model": "agent-model",
+        "messages": [{"role": "user", "content": "same"}],
+        "stream": False,
+    }
+
+    async def run_test() -> tuple[httpx.Response, httpx.Response, dict[str, Any] | None]:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            retryable = await client.post("/v1/chat/completions", json=body)
+            terminal = await client.post("/v1/chat/completions", json=body)
+        remaining_error = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+        return retryable, terminal, remaining_error
+
+    retryable, terminal, remaining_error = asyncio.run(run_test())
+
+    assert retryable.status_code == 503
+    assert terminal.status_code == 500
+    assert request_count == 2
+    assert remaining_error is not None
+    assert remaining_error["status_code"] == 500
 
 
 def test_rollout_proxy_matches_any_chat_completion_prefix():
@@ -2578,3 +2806,553 @@ def test_rollout_proxy_recognizes_partial_staleness_invalidated_response():
     )
 
     assert recorded == payload["detail"]
+
+
+def _in_stream_error_event(error: dict[str, Any]) -> bytes:
+    return f"data: {json.dumps({'error': error})}\n\n".encode("utf-8")
+
+
+def test_rollout_proxy_sniffs_in_stream_context_overflow():
+    proxy = _make_proxy()
+    overflow_error = {
+        "type": "dressage_proxy_error",
+        "code": "context_overflow",
+        "message": "Dressage proxy context window overflow.",
+        "details": {"phase": "input_output", "context_window": 4096},
+        "status_code": 413,
+    }
+    error_event = _in_stream_error_event(overflow_error)
+    split_at = len(error_event) // 2
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncByteStream(
+                [
+                    b": dressage-heartbeat\n\n",
+                    b": dressage-heartbeat\n\n",
+                    error_event[:split_at],
+                    error_event[split_at:],
+                    b"data: [DONE]\n\n",
+                ]
+            ),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            async with client.stream(
+                "POST",
+                "/v1/chat/completions",
+                json={"model": "proxy-model", "stream": True, "messages": []},
+            ) as response:
+                response_body = await response.aread()
+        await proxy.drain_turn(timeout=1.0)
+        overflow = await proxy.consume_context_overflow_error()
+        failed = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        assert response.status_code == 200
+        assert b": dressage-heartbeat" in response_body
+        assert b'"context_overflow"' in response_body
+        assert b"data: [DONE]" in response_body
+        assert overflow == overflow_error
+        assert failed is not None
+        assert failed["status_code"] == 413
+
+    asyncio.run(run_test())
+
+
+def test_rollout_proxy_sniffs_in_stream_rollout_invalidated():
+    proxy = _make_proxy()
+    invalidated_error = {
+        "type": "dressage_proxy_error",
+        "code": "generation_preempted",
+        "message": "stale",
+        "status_code": 502,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncByteStream(
+                [
+                    b": ping\n\n",
+                    _in_stream_error_event(invalidated_error),
+                    b"data: [DONE]\n\n",
+                ]
+            ),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            async with client.stream(
+                "POST",
+                "/v1/chat/completions",
+                json={"model": "proxy-model", "stream": True, "messages": []},
+            ) as response:
+                response_body = await response.aread()
+        await proxy.drain_turn(timeout=1.0)
+        invalidated = await proxy.consume_rollout_invalidated_error()
+        failed = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        assert response.status_code == 200
+        assert b"generation_preempted" not in response_body
+        assert b"chatcmpl-rollout-invalidated" in response_body
+        assert b"data: [DONE]" in response_body
+        assert invalidated == invalidated_error
+        assert failed is None
+
+    asyncio.run(run_test())
+
+
+def test_rollout_proxy_anthropic_stream_sniffs_error_and_forwards_ping():
+    proxy = _make_proxy()
+    overflow_error = {
+        "type": "dressage_proxy_error",
+        "code": "context_overflow",
+        "message": "Dressage proxy context window overflow.",
+        "details": {"phase": "input_output"},
+        "status_code": 413,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncByteStream(
+                [
+                    b": dressage-heartbeat\n\n",
+                    _in_stream_error_event(overflow_error),
+                    b"data: [DONE]\n\n",
+                ]
+            ),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001", backend_session_id="claude-session-1")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            async with client.stream(
+                "POST",
+                "/v1/messages",
+                json={"model": "proxy-model", "max_tokens": 128, "stream": True, "messages": []},
+            ) as response:
+                response_body = await response.aread()
+        await proxy.drain_turn(timeout=1.0)
+        overflow = await proxy.consume_context_overflow_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        assert response.status_code == 200
+        assert b"event: ping" in response_body
+        assert b"event: message_start" in response_body
+        assert b"event: message_stop" in response_body
+        assert b"context_overflow" not in response_body
+        assert overflow == overflow_error
+
+    asyncio.run(run_test())
+
+
+def test_rollout_proxy_anthropic_stream_emits_terminal_failed_upstream_error():
+    proxy = _make_proxy()
+    upstream_error = {
+        "code": "sglang_upstream_unavailable",
+        "message": "SGLang generation failed.",
+        "status_code": 503,
+    }
+    error_event = _in_stream_error_event(upstream_error).replace(b"\n", b"\r\n")
+    split_at = len(error_event) // 2
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncByteStream(
+                [
+                    b": ping\r\n\r\n",
+                    error_event[:split_at],
+                    error_event[split_at:],
+                    b"data: [DONE]\r\n\r\n",
+                ]
+            ),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001", backend_session_id="claude-session-1")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            async with client.stream(
+                "POST",
+                "/v1/messages",
+                json={"model": "proxy-model", "max_tokens": 128, "stream": True, "messages": []},
+            ) as response:
+                response_body = await response.aread()
+        await proxy.drain_turn(timeout=1.0)
+        failed = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        assert response.status_code == 200
+        assert b"event: ping" in response_body
+        assert b"event: error" in response_body
+        assert b'"type": "upstream_error"' in response_body
+        assert b"HTTP 503" in response_body
+        assert b"event: message_stop" not in response_body
+        assert failed is not None
+        assert failed["status_code"] == 503
+
+    asyncio.run(run_test())
+
+
+def test_rollout_proxy_anthropic_stream_keeps_invalidated_as_graceful_end():
+    proxy = _make_proxy()
+    invalidated_error = {
+        "code": "generation_preempted",
+        "message": "Generation was preempted.",
+        "status_code": 502,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncByteStream(
+                [_in_stream_error_event(invalidated_error), b"data: [DONE]\n\n"]
+            ),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001", backend_session_id="claude-session-1")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            async with client.stream(
+                "POST",
+                "/v1/messages",
+                json={"model": "proxy-model", "max_tokens": 128, "stream": True, "messages": []},
+            ) as response:
+                response_body = await response.aread()
+        await proxy.drain_turn(timeout=1.0)
+        invalidated = await proxy.consume_rollout_invalidated_error()
+        failed = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        assert response.status_code == 200
+        assert b"event: message_stop" in response_body
+        assert b"event: error" not in response_body
+        assert invalidated == invalidated_error
+        assert failed is None
+
+    asyncio.run(run_test())
+
+
+def test_rollout_proxy_sniffs_terminal_error_without_sse_delimiter():
+    proxy = _make_proxy()
+    upstream_error = {
+        "code": "sglang_upstream_unavailable",
+        "message": "SGLang generation failed.",
+        "status_code": 503,
+    }
+    terminal_event = _in_stream_error_event(upstream_error).removesuffix(b"\n\n")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncByteStream([terminal_event]),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            async with client.stream(
+                "POST",
+                "/v1/chat/completions",
+                json={"model": "proxy-model", "stream": True, "messages": []},
+            ) as response:
+                response_body = await response.aread()
+        await proxy.drain_turn(timeout=1.0)
+        failed = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        assert response_body == terminal_event
+        assert failed is not None
+        assert failed["status_code"] == 503
+
+    asyncio.run(run_test())
+
+
+def test_rollout_proxy_rejects_invalid_embedded_http_statuses():
+    proxy = _make_proxy()
+
+    for status_code in (399, 600, "503", True):
+        assert (
+            proxy._in_stream_error_from_chunk(
+                {"error": {"code": "backend_error", "status_code": status_code}}
+            )
+            is None
+        )
+
+    assert (
+        proxy._in_stream_error_from_chunk(
+            {"error": {"code": "backend_error", "status_code": 599}}
+        )
+        is not None
+    )
+
+
+@pytest.mark.parametrize(
+    ("method_name", "extra_args"),
+    [
+        ("_stream_proxy", ()),
+        ("_stream_anthropic_messages_proxy", ()),
+        ("_stream_openai_responses_proxy", ({},)),
+    ],
+)
+def test_rollout_proxy_stream_error_body_cancellation_finishes_request(
+    method_name: str,
+    extra_args: tuple[Any, ...],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    proxy = _make_proxy()
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient()
+        await proxy.open_turn("turn-001")
+        snapshot = await proxy._enter_chat_request()
+        assert snapshot.scope is not None
+        stream = BlockingAsyncByteStream()
+
+        async def send_stream_request(*_args: Any) -> httpx.Response:
+            return httpx.Response(
+                503,
+                stream=stream,
+                request=httpx.Request("POST", "http://upstream/v1/chat/completions"),
+            )
+
+        monkeypatch.setattr(proxy, "_send_stream_request", send_stream_request)
+        method = getattr(proxy, method_name)
+        task = asyncio.create_task(
+            method("http://upstream/v1/chat/completions", b"{}", {}, snapshot, *extra_args)
+        )
+        await asyncio.wait_for(stream.started.wait(), timeout=1.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert stream.closed.is_set()
+        assert snapshot.scope.inflight_requests == 0
+        assert snapshot.scope.drained.is_set()
+        await proxy._client.aclose()
+
+    asyncio.run(run_test())
+
+
+def test_rollout_proxy_stream_close_error_still_finishes_request(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    proxy = _make_proxy()
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient()
+        await proxy.open_turn("turn-001")
+        snapshot = await proxy._enter_chat_request()
+        assert snapshot.scope is not None
+        stream = RaisingCloseAsyncByteStream([b"data: [DONE]\n\n"])
+
+        async def send_stream_request(*_args: Any) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=stream,
+                request=httpx.Request("POST", "http://upstream/v1/chat/completions"),
+            )
+
+        monkeypatch.setattr(proxy, "_send_stream_request", send_stream_request)
+        response = await proxy._stream_proxy(
+            "http://upstream/v1/chat/completions",
+            b"{}",
+            {},
+            snapshot,
+        )
+        with pytest.raises(RuntimeError, match="upstream close failed"):
+            async for _ in response.body_iterator:
+                pass
+
+        assert snapshot.scope.inflight_requests == 0
+        assert snapshot.scope.drained.is_set()
+        await proxy._client.aclose()
+
+    asyncio.run(run_test())
+
+
+def test_rollout_proxy_openai_responses_forwards_heartbeat_comment():
+    proxy = _make_proxy()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncByteStream(
+                [
+                    b": dressage-heartbeat\n\n",
+                    _sse_event(
+                        {
+                            "id": "chatcmpl-stream",
+                            "choices": [{"delta": {"content": "ok"}}],
+                        }
+                    ),
+                    b"data: [DONE]\n\n",
+                ]
+            ),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001", backend_session_id="codex-session-1")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            async with client.stream(
+                "POST",
+                "/v1/responses",
+                json={"model": "proxy-model", "input": "hi", "stream": True},
+            ) as response:
+                response_body = await response.aread()
+        await proxy.drain_turn(timeout=1.0)
+        failed = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        assert response.status_code == 200
+        assert b": dressage-heartbeat" in response_body
+        assert b"event: response.completed" in response_body
+        assert failed is None
+
+    asyncio.run(run_test())
+
+
+def test_rollout_proxy_openai_responses_emits_terminal_failed_upstream_error():
+    proxy = _make_proxy()
+    upstream_error = {
+        "code": "sglang_upstream_unavailable",
+        "message": "router unavailable",
+        "status_code": 503,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncByteStream(
+                [
+                    b": dressage-heartbeat\n\n",
+                    _in_stream_error_event(upstream_error),
+                    b"data: [DONE]\n\n",
+                ]
+            ),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001", backend_session_id="codex-session-1")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            async with client.stream(
+                "POST",
+                "/v1/responses",
+                json={"model": "proxy-model", "input": "hi", "stream": True},
+            ) as response:
+                response_body = await response.aread()
+        await proxy.drain_turn(timeout=1.0)
+        failed = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        events = _sse_events_from_body(response_body)
+        assert response.status_code == 200
+        assert b": dressage-heartbeat" in response_body
+        assert any(name == "error" for name, _ in events)
+        assert not any(name == "response.completed" for name, _ in events)
+        assert failed is not None
+        assert failed["status_code"] == 503
+
+    asyncio.run(run_test())
+
+
+def test_rollout_proxy_openai_responses_keeps_invalidated_as_graceful_completion():
+    proxy = _make_proxy()
+    invalidated_error = {
+        "code": "generation_preempted",
+        "message": "Generation was preempted.",
+        "status_code": 502,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncByteStream(
+                [_in_stream_error_event(invalidated_error), b"data: [DONE]\n\n"]
+            ),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001", backend_session_id="codex-session-1")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            async with client.stream(
+                "POST",
+                "/v1/responses",
+                json={"model": "proxy-model", "input": "hi", "stream": True},
+            ) as response:
+                response_body = await response.aread()
+        await proxy.drain_turn(timeout=1.0)
+        invalidated = await proxy.consume_rollout_invalidated_error()
+        failed = await proxy.consume_failed_upstream_error()
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+        events = _sse_events_from_body(response_body)
+        assert response.status_code == 200
+        assert any(name == "response.completed" for name, _ in events)
+        assert not any(name == "error" for name, _ in events)
+        assert invalidated == invalidated_error
+        assert failed is None
+
+    asyncio.run(run_test())

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -485,6 +485,75 @@ class BlockingSGLangClient(FakeSGLangClient):
         )
 
 
+class AsyncBlockingSGLangClient(FakeSGLangClient):
+    def __init__(self, responses: list[SGLangResponse]):
+        super().__init__(responses)
+        self.first_call_started = asyncio.Event()
+        self.release_first_call = asyncio.Event()
+        self.abort_calls: list[dict[str, Any]] = []
+
+    async def generate(
+        self,
+        input_ids,
+        sampling_params,
+        *,
+        routing_key=None,
+        request_id=None,
+        return_logprob=True,
+        logprob_start_len=0,
+    ):
+        self.calls.append(
+            {
+                "input_ids": list(input_ids),
+                "sampling_params": dict(sampling_params),
+                "routing_key": routing_key,
+                "request_id": request_id,
+                "return_logprob": return_logprob,
+                "logprob_start_len": logprob_start_len,
+            }
+        )
+        self.last_routing_key = routing_key
+        self.first_call_started.set()
+        await self.release_first_call.wait()
+        return self._hydrate_response(
+            self._responses.pop(0),
+            input_ids,
+            expect_input_logprobs=bool(return_logprob and logprob_start_len == 0),
+        )
+
+    async def abort_request(self, request_id, *, routing_key=None):
+        self.abort_calls.append(
+            {
+                "request_id": request_id,
+                "routing_key": routing_key,
+            }
+        )
+        self.release_first_call.set()
+        return {"request_id": request_id, "aborted": True}
+
+
+class SlowSGLangClient(FakeSGLangClient):
+    """Delays generate to keep requests in flight past the heartbeat grace."""
+
+    def __init__(
+        self,
+        responses: list[SGLangResponse],
+        *,
+        delay: float,
+        error: Exception | None = None,
+    ):
+        super().__init__(responses)
+        self.delay = delay
+        self.error = error
+
+    async def generate(self, input_ids, sampling_params, **kwargs):
+        await asyncio.sleep(self.delay)
+        if self.error is not None:
+            raise self.error
+        kwargs.pop("request_id", None)
+        return await super().generate(input_ids, sampling_params, **kwargs)
+
+
 class TemplateMismatchTokenizer(FakeTokenizer):
     def _maybe_adjust_rendered(
         self,
@@ -797,6 +866,7 @@ def make_client(
     use_rollout_routing_replay: bool = False,
     partial_rollout: bool = False,
     max_partial_rollout_preempts: int | None = None,
+    stream_heartbeat_interval_seconds: float = 15.0,
 ):
     session_manager = SessionManager()
     trajectory_store = TrajectoryStore(min_group_size=1, group_timeout=0.0)
@@ -825,6 +895,7 @@ def make_client(
         use_rollout_routing_replay=use_rollout_routing_replay,
         partial_rollout=partial_rollout,
         max_partial_rollout_preempts=max_partial_rollout_preempts,
+        stream_heartbeat_interval_seconds=stream_heartbeat_interval_seconds,
     )
     if tool_call_parser is not _UNSET:
         create_app_kwargs["tool_call_parser"] = tool_call_parser
@@ -876,6 +947,7 @@ def test_proxy_health_reports_sampling_limits():
         make_response("hello"),
         rollout_temperature=0.7,
         max_output_tokens=2048,
+        stream_heartbeat_interval_seconds=7.5,
     )
 
     result = client.get("/health")
@@ -884,6 +956,7 @@ def test_proxy_health_reports_sampling_limits():
     config = result.json()["config"]
     assert config["rollout_temperature"] == 0.7
     assert config["max_output_tokens"] == 2048
+    assert config["stream_heartbeat_interval_seconds"] == 7.5
 
 
 def test_integration_capabilities_require_auth_and_report_version():
@@ -1311,6 +1384,7 @@ def test_parse_args_defaults_to_sglang_api_parser_backends(monkeypatch):
     assert args.context_window is None
     assert args.max_output_tokens is None
     assert args.dynamic_max_tokens is True
+    assert args.stream_heartbeat_interval_seconds == 15.0
 
 
 def test_parse_args_rejects_non_positive_context_window(monkeypatch):
@@ -1358,6 +1432,36 @@ def test_parse_args_rejects_non_positive_max_output_tokens(monkeypatch, value):
 def test_create_app_rejects_non_positive_max_output_tokens(value):
     with pytest.raises(ValueError, match="max_output_tokens must be greater than 0"):
         create_app(max_output_tokens=value)
+
+
+@pytest.mark.parametrize("value", ["-1", "nan", "inf"])
+def test_parse_args_rejects_invalid_stream_heartbeat_interval_seconds(
+    monkeypatch, value
+):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "dressage.proxy.server",
+            "--tokenizer-path",
+            "fake-tokenizer",
+            "--stream-heartbeat-interval-seconds",
+            value,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args()
+
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize("value", [-1.0, float("nan"), float("inf")])
+def test_create_app_rejects_invalid_stream_heartbeat_interval_seconds(value):
+    with pytest.raises(
+        ValueError,
+        match="stream_heartbeat_interval_seconds must be a finite number",
+    ):
+        create_app(stream_heartbeat_interval_seconds=value)
 
 
 def test_parse_args_can_disable_dynamic_max_tokens(monkeypatch):
@@ -3329,6 +3433,220 @@ def test_streaming_emits_usage_chunk_before_done():
     assert usage_event["model"] == "fake-model"
     assert usage["prompt_tokens"] == len(sglang_client.calls[0]["input_ids"])
     assert usage["completion_tokens"] == len(raw_text)
+
+
+def test_stream_heartbeat_emits_keepalive_before_chunks():
+    raw_text = "heartbeat hello"
+    slow_client = SlowSGLangClient([make_response(raw_text)], delay=0.3)
+    client, _, _, _ = make_client(
+        sglang_client=slow_client, stream_heartbeat_interval_seconds=0.05
+    )
+
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        headers={"X-Session-Id": "sess-hb", "X-Instance-Id": "inst-hb"},
+        json={
+            "model": "fake-model",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    ) as response:
+        body = "".join(response.iter_text())
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-cache, no-transform"
+    assert response.headers["x-accel-buffering"] == "no"
+    assert body.count(": dressage-heartbeat") >= 2
+    assert body.index(": dressage-heartbeat") < body.index("data:")
+    assert f'"content": "{raw_text[:8]}"' in body or f'"content":"{raw_text[:8]}"' in body
+    assert_stream_usage_chunk(body)
+
+
+def test_stream_heartbeat_fast_completion_matches_legacy_stream():
+    raw_text = "quick reply"
+    client, _, _, _ = make_client(
+        make_response(raw_text), stream_heartbeat_interval_seconds=5.0
+    )
+
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        headers={"X-Session-Id": "sess-hb-fast", "X-Instance-Id": "inst-hb-fast"},
+        json={
+            "model": "fake-model",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    ) as response:
+        body = "".join(response.iter_text())
+
+    assert response.status_code == 200
+    assert ": dressage-heartbeat" not in body
+    assert_stream_usage_chunk(body)
+
+
+def test_stream_heartbeat_can_be_disabled():
+    raw_text = "heartbeat disabled"
+    slow_client = SlowSGLangClient([make_response(raw_text)], delay=0.05)
+    client, _, _, _ = make_client(
+        sglang_client=slow_client,
+        stream_heartbeat_interval_seconds=0,
+    )
+
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        headers={"X-Session-Id": "sess-hb-off", "X-Instance-Id": "inst-hb-off"},
+        json={
+            "model": "fake-model",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    ) as response:
+        body = "".join(response.iter_text())
+
+    assert response.status_code == 200
+    assert ": dressage-heartbeat" not in body
+    assert_stream_usage_chunk(body)
+
+
+def test_stream_heartbeat_preserves_status_code_for_fast_errors():
+    client, _, _, _ = make_client(
+        make_response("unused"),
+        context_window=4,
+        stream_heartbeat_interval_seconds=5.0,
+    )
+
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"X-Session-Id": "sess-hb-413", "X-Instance-Id": "inst-hb-413"},
+        json={
+            "model": "fake-model",
+            "stream": True,
+            "messages": [{"role": "user", "content": "way too long prompt"}],
+        },
+    )
+
+    assert response.status_code == 413
+    assert response.json()["error"] == "context_overflow"
+
+
+def test_stream_heartbeat_reports_late_error_in_stream():
+    slow_client = SlowSGLangClient(
+        [], delay=0.3, error=httpx.ConnectError("router down")
+    )
+    client, _, _, _ = make_client(
+        sglang_client=slow_client, stream_heartbeat_interval_seconds=0.05
+    )
+
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        headers={"X-Session-Id": "sess-hb-err", "X-Instance-Id": "inst-hb-err"},
+        json={
+            "model": "fake-model",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    ) as response:
+        body = "".join(response.iter_text())
+
+    assert response.status_code == 200
+    assert ": dressage-heartbeat" in body
+    assert sse_data_values(body)[-1] == "[DONE]"
+    events = sse_json_events(body)
+    error_events = [event for event in events if "error" in event]
+    assert len(error_events) == 1
+    error = error_events[0]["error"]
+    assert error["status_code"] == 503
+    assert "error" not in error
+    assert error["code"] == "sglang_upstream_unavailable"
+    assert error["type"] == "dressage_proxy_error"
+    assert error["message"] == "router down"
+
+
+def test_stream_heartbeat_reports_unknown_late_error_without_details():
+    slow_client = SlowSGLangClient(
+        [],
+        delay=0.05,
+        error=RuntimeError("sensitive internal detail"),
+    )
+    client, _, _, _ = make_client(
+        sglang_client=slow_client,
+        stream_heartbeat_interval_seconds=0.01,
+    )
+
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        headers={
+            "X-Session-Id": "sess-hb-internal",
+            "X-Instance-Id": "inst-hb-internal",
+        },
+        json={
+            "model": "fake-model",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    ) as response:
+        body = "".join(response.iter_text())
+
+    assert response.status_code == 200
+    assert ": dressage-heartbeat" in body
+    error = next(event["error"] for event in sse_json_events(body) if "error" in event)
+    assert error == {
+        "code": "internal_error",
+        "message": "Internal proxy error.",
+        "type": "dressage_proxy_error",
+        "status_code": 500,
+    }
+    assert "sensitive internal detail" not in body
+
+
+def test_stream_cancellation_aborts_generation():
+    async def run_test() -> None:
+        sglang_client = AsyncBlockingSGLangClient([make_response("unused")])
+        sync_client, session_manager, _, _ = make_client(
+            sglang_client=sglang_client,
+            stream_heartbeat_interval_seconds=0.01,
+        )
+        headers = {
+            "X-Session-Id": "sess-disconnect-abort",
+            "X-Instance-Id": "inst-abort",
+            "X-Turn-Id": "turn-1",
+        }
+        body = {
+            "model": "fake-model",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=sync_client.app),
+            base_url="http://test",
+        ) as client:
+            request = asyncio.create_task(
+                client.post("/v1/chat/completions", json=body, headers=headers)
+            )
+            await asyncio.wait_for(
+                sglang_client.first_call_started.wait(),
+                timeout=1.0,
+            )
+            await asyncio.sleep(0.03)
+            request.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await request
+
+            pause_state = (await client.get("/v1/rollout/pause_state")).json()
+
+        assert len(sglang_client.abort_calls) == 1
+        assert pause_state["active_sglang_generations"] == 0
+        session = session_manager.get_session("sess-disconnect-abort")
+        assert session is not None
+        assert session.steps == []
+
+    asyncio.run(run_test())
 
 
 def test_streaming_include_usage_true_and_bad_options_default_to_usage():
@@ -5661,6 +5979,37 @@ def test_generation_controller_rejects_preempt_without_partial_resume():
     asyncio.run(run_test())
 
     assert len(sglang_client.calls) == 1
+
+
+def test_generation_controller_cancellation_aborts_active_request():
+    from dressage.proxy.generation_controller import GenerationController
+
+    async def run_test() -> None:
+        sglang_client = AsyncBlockingSGLangClient([make_response("late")])
+        controller = GenerationController(sglang_client)
+        generation = asyncio.create_task(
+            controller.generate_preemptible(
+                [1],
+                {"max_new_tokens": 1},
+                session_id="sess-cancelled-stream",
+                instance_id="inst-cancelled-stream",
+                turn_id="turn-cancelled-stream",
+            )
+        )
+        await asyncio.wait_for(
+            sglang_client.first_call_started.wait(),
+            timeout=1.0,
+        )
+
+        generation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await generation
+
+        assert len(sglang_client.abort_calls) == 1
+        assert sglang_client.abort_calls[0]["request_id"]
+        assert controller.state()["active_sglang_generations"] == 0
+
+    asyncio.run(run_test())
 
 
 def test_generation_controller_rejects_stale_epoch_before_sglang():


### PR DESCRIPTION
## Summary

- send periodic SSE comment heartbeats while a streaming model request is waiting for a long-running generation
- make the heartbeat interval configurable with `--stream-heartbeat-interval-seconds` (15 seconds by default; `0` disables it)
- propagate heartbeats through the BBS proxy for OpenAI Chat, Anthropic Messages, and OpenAI Responses clients
- recognize errors that arrive inside an already-started HTTP 200 stream and surface context overflow, rollout invalidation, and upstream failures through the adapters
- close upstream responses, release inflight accounting, and wait for backend cleanup when requests are cancelled
- preserve the existing behavior for non-streaming requests, disabled heartbeats, and responses that finish before the first heartbeat

## Motivation

The proxy waits for SGLang generation to finish before emitting its pseudo-streamed completion. During a long agent model call, the proxy-to-BBS and BBS-to-agent connections can otherwise remain idle long enough for a read timeout or intermediary to close them.

Once a heartbeat commits HTTP 200, a later generation failure can no longer use its original HTTP status. The BBS layer therefore also needs to classify the terminal SSE error event after the stream drains instead of treating the request as successful.

## Error and compatibility behavior

- fast failures retain their original HTTP status because headers are not committed before the first heartbeat
- late failures are emitted as terminal SSE error events and recorded by BBS for adapter-level error handling
- OpenAI Chat keeps SSE comments, Anthropic receives protocol-native `ping` events, and OpenAI Responses receives valid SSE keepalive comments
- rollout invalidation remains a graceful synthetic completion while its marker is surfaced after drain
- retryable upstream markers are cleared by a later successful attempt without allowing concurrent older requests to overwrite newer outcomes
- Claude Code, OpenClaw, OpenCode, and Codex adapters drain the proxy before consuming failure markers
- non-streaming requests continue through the existing request pipeline unchanged

## Validation

- BBS, heartbeat proxy, and proxy-client regression suites: `392 passed`
- additional Harbor socket/cancellation regressions: `4 passed`
- Python compilation and `git diff --check` passed
- the repository-wide run also reached `848 passed`; remaining collection/test failures are pre-existing on `origin/main` (missing local `torch`, reward-registry test mismatch, and Dockerfile expectation mismatch)

No live long-running SGLang/BBS end-to-end smoke test was run.