### PR TITLE
feat(proxy): SSE heartbeat keepalive between Dressage proxy and black…

### DIFF
--- a/blackbox_server/adapters/base.py
+++ b/blackbox_server/adapters/base.py
@@ -117,7 +117,10 @@ class BackendContextOverflowError(BackendError):
 def backend_context_overflow_from_proxy_payload(
     payload: object,
 ) -> BackendContextOverflowError | None:
-    if not isinstance(payload, dict) or payload.get("error") != "context_overflow":
+    if (
+        not isinstance(payload, dict)
+        or (payload.get("code") or payload.get("error")) != "context_overflow"
+    ):
         return None
     details = payload.get("details")
     if not isinstance(details, dict):

--- a/blackbox_server/proxy/rollout_llm_proxy.py
+++ b/blackbox_server/proxy/rollout_llm_proxy.py
@@ -6,7 +6,7 @@ import logging
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, AsyncIterator, Mapping
 
 import httpx
 from fastapi import FastAPI, Request
@@ -1064,14 +1064,33 @@ class RolloutLLMProxy:
             raise
 
         if upstream_response.status_code >= 400:
+            error_status: int | None = upstream_response.status_code
             error_body = await upstream_response.aread()
+            error_content_type: str | None = None
+            first_bytes = b""
+            byte_iter: AsyncIterator[bytes] | None = None
+        else:
+            error_status = None
+            error_body = b""
+            error_content_type = None
+            byte_iter = upstream_response.aiter_bytes()
+            first_bytes, sniffed = await self._drain_keepalive_prelude(byte_iter)
+            if sniffed is not None:
+                error_status, error_body = sniffed
+                # The heartbeat stream committed text/event-stream upstream, but
+                # the recovered body is the JSON a plain error response carries.
+                error_content_type = "application/json"
+
+        if error_status is not None:
             response_headers = dict(upstream_response.headers)
             response_headers.pop("content-encoding", None)
             response_headers.pop("transfer-encoding", None)
             response_headers.pop("content-length", None)
+            if error_content_type is not None:
+                response_headers["content-type"] = error_content_type
             self._log_upstream_error(
                 url=url,
-                status_code=upstream_response.status_code,
+                status_code=error_status,
                 response_headers=dict(upstream_response.headers),
                 response_body=error_body,
                 retried=False,
@@ -1079,12 +1098,12 @@ class RolloutLLMProxy:
             if snapshot is not None and snapshot.scope is not None:
                 await self._record_context_overflow_error(
                     snapshot.scope,
-                    status_code=upstream_response.status_code,
+                    status_code=error_status,
                     response_body=error_body,
                 )
                 if await self._record_rollout_invalidated_error(
                     snapshot.scope,
-                    status_code=upstream_response.status_code,
+                    status_code=error_status,
                     response_body=error_body,
                 ):
                     await upstream_response.aclose()
@@ -1093,7 +1112,7 @@ class RolloutLLMProxy:
             await self._record_failed_upstream_error(
                 snapshot,
                 url=url,
-                status_code=upstream_response.status_code,
+                status_code=error_status,
                 request_headers=headers,
                 request_body=body,
                 response_headers=dict(upstream_response.headers),
@@ -1104,13 +1123,16 @@ class RolloutLLMProxy:
                 await self._mark_request_finished(snapshot.scope)
             return Response(
                 content=error_body,
-                status_code=upstream_response.status_code,
+                status_code=error_status,
                 headers=response_headers,
             )
 
+        assert byte_iter is not None
+
         async def _forward():
             try:
-                async for chunk in upstream_response.aiter_bytes():
+                yield first_bytes
+                async for chunk in byte_iter:
                     yield chunk
             finally:
                 await upstream_response.aclose()
@@ -1144,10 +1166,22 @@ class RolloutLLMProxy:
             raise
 
         if upstream_response.status_code >= 400:
+            error_status: int | None = upstream_response.status_code
             error_body = await upstream_response.aread()
+            first_bytes = b""
+            byte_iter: AsyncIterator[bytes] | None = None
+        else:
+            error_status = None
+            error_body = b""
+            byte_iter = upstream_response.aiter_bytes()
+            first_bytes, sniffed = await self._drain_keepalive_prelude(byte_iter)
+            if sniffed is not None:
+                error_status, error_body = sniffed
+
+        if error_status is not None:
             self._log_upstream_error(
                 url=url,
-                status_code=upstream_response.status_code,
+                status_code=error_status,
                 response_headers=dict(upstream_response.headers),
                 response_body=error_body,
                 retried=False,
@@ -1155,12 +1189,12 @@ class RolloutLLMProxy:
             if snapshot is not None and snapshot.scope is not None:
                 await self._record_context_overflow_error(
                     snapshot.scope,
-                    status_code=upstream_response.status_code,
+                    status_code=error_status,
                     response_body=error_body,
                 )
                 if await self._record_rollout_invalidated_error(
                     snapshot.scope,
-                    status_code=upstream_response.status_code,
+                    status_code=error_status,
                     response_body=error_body,
                 ):
                     await upstream_response.aclose()
@@ -1169,7 +1203,7 @@ class RolloutLLMProxy:
             await self._record_failed_upstream_error(
                 snapshot,
                 url=url,
-                status_code=upstream_response.status_code,
+                status_code=error_status,
                 request_headers=headers,
                 request_body=body,
                 response_headers=dict(upstream_response.headers),
@@ -1178,19 +1212,24 @@ class RolloutLLMProxy:
             await upstream_response.aclose()
             if snapshot is not None and snapshot.scope is not None:
                 await self._mark_request_finished(snapshot.scope)
-            if 500 <= upstream_response.status_code < 600:
+            if 500 <= error_status < 600:
                 return self._anthropic_non_retry_upstream_error_response(
-                    upstream_status_code=upstream_response.status_code,
+                    upstream_status_code=error_status,
                     response_body=error_body,
                 )
             return self._anthropic_error_response_from_bytes(
-                status_code=upstream_response.status_code,
+                status_code=error_status,
                 response_body=error_body,
             )
 
+        assert byte_iter is not None
+
         async def _forward():
             try:
-                async for event in self._iter_anthropic_events_from_openai_stream(upstream_response):
+                async for event in self._iter_anthropic_events_from_openai_stream(
+                    first_bytes,
+                    byte_iter,
+                ):
                     yield event
             finally:
                 await upstream_response.aclose()
@@ -1220,14 +1259,33 @@ class RolloutLLMProxy:
             raise
 
         if upstream_response.status_code >= 400:
+            error_status: int | None = upstream_response.status_code
             error_body = await upstream_response.aread()
+            error_content_type: str | None = None
+            first_bytes = b""
+            byte_iter: AsyncIterator[bytes] | None = None
+        else:
+            error_status = None
+            error_body = b""
+            error_content_type = None
+            byte_iter = upstream_response.aiter_bytes()
+            first_bytes, sniffed = await self._drain_keepalive_prelude(byte_iter)
+            if sniffed is not None:
+                error_status, error_body = sniffed
+                # The heartbeat stream committed text/event-stream upstream, but
+                # the recovered body is the JSON a plain error response carries.
+                error_content_type = "application/json"
+
+        if error_status is not None:
             response_headers = dict(upstream_response.headers)
             response_headers.pop("content-encoding", None)
             response_headers.pop("transfer-encoding", None)
             response_headers.pop("content-length", None)
+            if error_content_type is not None:
+                response_headers["content-type"] = error_content_type
             self._log_upstream_error(
                 url=url,
-                status_code=upstream_response.status_code,
+                status_code=error_status,
                 response_headers=dict(upstream_response.headers),
                 response_body=error_body,
                 retried=False,
@@ -1235,12 +1293,12 @@ class RolloutLLMProxy:
             if snapshot is not None and snapshot.scope is not None:
                 await self._record_context_overflow_error(
                     snapshot.scope,
-                    status_code=upstream_response.status_code,
+                    status_code=error_status,
                     response_body=error_body,
                 )
                 if await self._record_rollout_invalidated_error(
                     snapshot.scope,
-                    status_code=upstream_response.status_code,
+                    status_code=error_status,
                     response_body=error_body,
                 ):
                     await upstream_response.aclose()
@@ -1249,7 +1307,7 @@ class RolloutLLMProxy:
             await self._record_failed_upstream_error(
                 snapshot,
                 url=url,
-                status_code=upstream_response.status_code,
+                status_code=error_status,
                 request_headers=headers,
                 request_body=body,
                 response_headers=dict(upstream_response.headers),
@@ -1260,14 +1318,17 @@ class RolloutLLMProxy:
                 await self._mark_request_finished(snapshot.scope)
             return Response(
                 content=error_body,
-                status_code=upstream_response.status_code,
+                status_code=error_status,
                 headers=response_headers,
             )
+
+        assert byte_iter is not None
 
         async def _forward():
             try:
                 async for event in self._iter_openai_response_events_from_chat_stream(
-                    upstream_response,
+                    first_bytes,
+                    byte_iter,
                     original_request,
                 ):
                     yield event
@@ -1281,6 +1342,60 @@ class RolloutLLMProxy:
             status_code=upstream_response.status_code,
             media_type="text/event-stream",
         )
+
+    async def _drain_keepalive_prelude(
+        self,
+        byte_iter: AsyncIterator[bytes],
+    ) -> tuple[bytes, tuple[int, bytes] | None]:
+        """Drop the Dressage keepalive comment frames that open a stream.
+
+        Returns the first real SSE frame together with whatever was buffered
+        behind it, plus the error sniffed from that frame when generation
+        failed.  Dressage pseudo-streams an already-computed result, so
+        heartbeats and the terminal error event can only precede the first real
+        frame; everything after it is forwarded verbatim.
+        """
+        buffer = b""
+        async for chunk in byte_iter:
+            buffer += chunk
+            while (index := buffer.find(b"\n\n")) >= 0:
+                frame, buffer = buffer[:index], buffer[index + 2 :]
+                if not frame.strip() or frame.lstrip(b"\r\n").startswith(b":"):
+                    continue
+                return frame + b"\n\n" + buffer, self._sniff_first_frame_error(frame)
+        return buffer, None
+
+    @staticmethod
+    def _sniff_first_frame_error(frame: bytes) -> tuple[int, bytes] | None:
+        """Recover the status code a heartbeat-committed failure would have used.
+
+        Heartbeats force the upstream to commit HTTP 200 before generation
+        finishes, so a late failure arrives as
+        ``data: {"error": {..., "status_code": N}}``.  The embedded payload is
+        the exact body a plain >=400 response would have carried, so it is
+        re-encoded and fed to the same classifiers.
+        """
+        try:
+            text = frame.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+        for payload in _payloads_from_sse_event(text):
+            if payload == "[DONE]":
+                continue
+            try:
+                parsed = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            error = parsed.get("error")
+            if not isinstance(error, dict):
+                continue
+            status_code = error.get("status_code")
+            if type(status_code) is not int or not 400 <= status_code <= 599:
+                continue
+            return status_code, json.dumps(error, ensure_ascii=False).encode("utf-8")
+        return None
 
     async def _send_plain_request(
         self,
@@ -1590,7 +1705,9 @@ class RolloutLLMProxy:
             payload = json.loads(response_body.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError):
             return None
-        if not isinstance(payload, dict) or payload.get("error") != "context_overflow":
+        if not isinstance(payload, dict) or (
+            payload.get("code") or payload.get("error")
+        ) != "context_overflow":
             return None
         return payload
 
@@ -1613,7 +1730,9 @@ class RolloutLLMProxy:
             candidate = detail
         else:
             candidate = payload
-        if candidate.get("error") not in DRESSAGE_ROLLOUT_INVALIDATED_ERRORS:
+        if (
+            candidate.get("code") or candidate.get("error")
+        ) not in DRESSAGE_ROLLOUT_INVALIDATED_ERRORS:
             return None
         return {str(key): value for key, value in candidate.items()}
 
@@ -1813,7 +1932,8 @@ class RolloutLLMProxy:
 
     async def _iter_openai_response_events_from_chat_stream(
         self,
-        upstream_response: httpx.Response,
+        first_bytes: bytes,
+        byte_iter: AsyncIterator[bytes],
         original_request: dict[str, Any],
     ):
         response_id = "resp_proxy_stream"
@@ -1839,7 +1959,7 @@ class RolloutLLMProxy:
             },
         )
 
-        async for payload_text in _iter_openai_sse_payloads(upstream_response):
+        async for payload_text in _iter_openai_sse_payloads(first_bytes, byte_iter):
             if payload_text == "[DONE]":
                 break
             try:
@@ -1982,10 +2102,14 @@ class RolloutLLMProxy:
             "usage": usage,
         }
 
-    async def _iter_anthropic_events_from_openai_stream(self, upstream_response: httpx.Response):
+    async def _iter_anthropic_events_from_openai_stream(
+        self,
+        first_bytes: bytes,
+        byte_iter: AsyncIterator[bytes],
+    ):
         state = _AnthropicStreamState()
         yield state.message_start(model="proxy-model")
-        async for payload in _iter_openai_sse_payloads(upstream_response):
+        async for payload in _iter_openai_sse_payloads(first_bytes, byte_iter):
             if payload == "[DONE]":
                 break
             try:
@@ -2941,16 +3065,23 @@ def _openai_finish_reason_to_anthropic(value: Any) -> str:
     return normalized
 
 
-async def _iter_openai_sse_payloads(response: httpx.Response):
-    buffer = ""
-    async for chunk in response.aiter_text():
+async def _iter_openai_sse_payloads(first_bytes: bytes, byte_iter: AsyncIterator[bytes]):
+    # Frame in the byte domain and decode whole events: the SSE separator is
+    # ASCII, so an event boundary never splits a multi-byte character, while
+    # decoding raw chunks would corrupt one that straddles a chunk boundary.
+    buffer = first_bytes
+    while (index := buffer.find(b"\n\n")) >= 0:
+        raw_event, buffer = buffer[:index], buffer[index + 2 :]
+        for payload in _payloads_from_sse_event(raw_event.decode("utf-8", errors="replace")):
+            yield payload
+    async for chunk in byte_iter:
         buffer += chunk
-        while "\n\n" in buffer:
-            raw_event, buffer = buffer.split("\n\n", 1)
-            for payload in _payloads_from_sse_event(raw_event):
+        while (index := buffer.find(b"\n\n")) >= 0:
+            raw_event, buffer = buffer[:index], buffer[index + 2 :]
+            for payload in _payloads_from_sse_event(raw_event.decode("utf-8", errors="replace")):
                 yield payload
     if buffer.strip():
-        for payload in _payloads_from_sse_event(buffer):
+        for payload in _payloads_from_sse_event(buffer.decode("utf-8", errors="replace")):
             yield payload
 
 

--- a/blackbox_server/proxy/rollout_llm_proxy.py
+++ b/blackbox_server/proxy/rollout_llm_proxy.py
@@ -1058,7 +1058,7 @@ class RolloutLLMProxy:
         assert self._client is not None
         try:
             upstream_response = await self._send_stream_request(url, body, headers)
-        except Exception:
+        except BaseException:
             if snapshot is not None and snapshot.scope is not None:
                 await self._mark_request_finished(snapshot.scope)
             raise
@@ -1074,7 +1074,16 @@ class RolloutLLMProxy:
             error_body = b""
             error_content_type = None
             byte_iter = upstream_response.aiter_bytes()
-            first_bytes, sniffed = await self._drain_keepalive_prelude(byte_iter)
+            try:
+                first_bytes, sniffed = await self._drain_keepalive_prelude(byte_iter)
+            except BaseException:
+                # The prelude awaits for the whole generation, so a disconnect
+                # or cancellation here must still release the connection and
+                # the request marker that _forward() would normally clean up.
+                await upstream_response.aclose()
+                if snapshot is not None and snapshot.scope is not None:
+                    await self._mark_request_finished(snapshot.scope)
+                raise
             if sniffed is not None:
                 error_status, error_body = sniffed
                 # The heartbeat stream committed text/event-stream upstream, but
@@ -1160,7 +1169,7 @@ class RolloutLLMProxy:
         assert self._client is not None
         try:
             upstream_response = await self._send_stream_request(url, body, headers)
-        except Exception:
+        except BaseException:
             if snapshot is not None and snapshot.scope is not None:
                 await self._mark_request_finished(snapshot.scope)
             raise
@@ -1174,7 +1183,16 @@ class RolloutLLMProxy:
             error_status = None
             error_body = b""
             byte_iter = upstream_response.aiter_bytes()
-            first_bytes, sniffed = await self._drain_keepalive_prelude(byte_iter)
+            try:
+                first_bytes, sniffed = await self._drain_keepalive_prelude(byte_iter)
+            except BaseException:
+                # The prelude awaits for the whole generation, so a disconnect
+                # or cancellation here must still release the connection and
+                # the request marker that _forward() would normally clean up.
+                await upstream_response.aclose()
+                if snapshot is not None and snapshot.scope is not None:
+                    await self._mark_request_finished(snapshot.scope)
+                raise
             if sniffed is not None:
                 error_status, error_body = sniffed
 
@@ -1253,7 +1271,7 @@ class RolloutLLMProxy:
         assert self._client is not None
         try:
             upstream_response = await self._send_stream_request(url, body, headers)
-        except Exception:
+        except BaseException:
             if snapshot is not None and snapshot.scope is not None:
                 await self._mark_request_finished(snapshot.scope)
             raise
@@ -1269,7 +1287,16 @@ class RolloutLLMProxy:
             error_body = b""
             error_content_type = None
             byte_iter = upstream_response.aiter_bytes()
-            first_bytes, sniffed = await self._drain_keepalive_prelude(byte_iter)
+            try:
+                first_bytes, sniffed = await self._drain_keepalive_prelude(byte_iter)
+            except BaseException:
+                # The prelude awaits for the whole generation, so a disconnect
+                # or cancellation here must still release the connection and
+                # the request marker that _forward() would normally clean up.
+                await upstream_response.aclose()
+                if snapshot is not None and snapshot.scope is not None:
+                    await self._mark_request_finished(snapshot.scope)
+                raise
             if sniffed is not None:
                 error_status, error_body = sniffed
                 # The heartbeat stream committed text/event-stream upstream, but

--- a/dressage/proxy/server.py
+++ b/dressage/proxy/server.py
@@ -7,6 +7,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import os
 import time
 import uuid
@@ -17,7 +18,7 @@ from typing import Any, Literal
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from transformers import AutoTokenizer
 
 from dressage.config import (
@@ -55,12 +56,59 @@ logger = logging.getLogger(__name__)
 _INPUT_TOKEN_VERSION = "-1"
 _DEFAULT_TOOL_CALL_PARSER = object()
 _NON_REAL_TOKEN_VERSIONS = {"", "-1", "unknown", "none"}
+_DEFAULT_STREAM_HEARTBEAT_INTERVAL_SECONDS = 15.0
+_SSE_HEARTBEAT = ": dressage-heartbeat\n\n"
+_SSE_RESPONSE_HEADERS = {
+    "Cache-Control": "no-cache, no-transform",
+    "X-Accel-Buffering": "no",
+}
 TokenBuildMode = Literal["tito", "snapshot"]
 SegmentView = Literal["lineage", "timeline"]
 
 
 def _canonical_json(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _response_json_payload(response: Response) -> Any:
+    body = bytes(response.body)
+    try:
+        return json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return {"message": body.decode("utf-8", "replace")}
+
+
+def _stream_error_chunk(status_code: int, payload: Any) -> str:
+    """Render an in-stream SSE error event.
+
+    Once heartbeat streaming has sent the response headers the HTTP status can
+    no longer change, so the failure is normalized into a terminal error event
+    that keeps the status code it would otherwise have carried.  The blackbox
+    proxy reads ``status_code`` back out to restore the original semantics.
+    """
+
+    error = dict(payload) if isinstance(payload, dict) else {"message": str(payload)}
+    raw_code = error.get("code") or error.get("error")
+    code = raw_code if isinstance(raw_code, str) and raw_code else "http_error"
+    raw_message = error.get("message") or error.get("detail")
+    message = (
+        raw_message
+        if isinstance(raw_message, str) and raw_message
+        else f"Dressage proxy error: {code}"
+    )
+    error.pop("error", None)
+    error["type"] = "dressage_proxy_error"
+    error["code"] = code
+    error["message"] = message
+    error["status_code"] = status_code
+    return f"data: {json.dumps({'error': error})}\n\n"
+
+
+def _consume_task_exception(task: asyncio.Task[Any]) -> None:
+    """Retrieve a detached pipeline exception to avoid an asyncio warning."""
+
+    if not task.cancelled():
+        task.exception()
 
 
 def _positive_int(value: str) -> int:
@@ -80,6 +128,18 @@ def _non_negative_int(value: str) -> int:
         raise argparse.ArgumentTypeError("must be an integer") from exc
     if parsed < 0:
         raise argparse.ArgumentTypeError("must be greater than or equal to 0")
+    return parsed
+
+
+def _non_negative_finite_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number") from exc
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError(
+            "must be a finite number greater than or equal to 0"
+        )
     return parsed
 
 
@@ -562,11 +622,22 @@ def create_app(
     use_rollout_routing_replay: bool = False,
     partial_rollout: bool = False,
     max_partial_rollout_preempts: int | None = None,
+    stream_heartbeat_interval_seconds: float = (
+        _DEFAULT_STREAM_HEARTBEAT_INTERVAL_SECONDS
+    ),
 ) -> FastAPI:
     """Create the Dressage proxy FastAPI app."""
 
     if context_window is not None and context_window <= 0:
         raise ValueError("context_window must be greater than 0 when provided")
+    if (
+        not math.isfinite(stream_heartbeat_interval_seconds)
+        or stream_heartbeat_interval_seconds < 0
+    ):
+        raise ValueError(
+            "stream_heartbeat_interval_seconds must be a finite number "
+            "greater than or equal to 0"
+        )
     if max_output_tokens is not None and max_output_tokens <= 0:
         raise ValueError("max_output_tokens must be greater than 0")
     if max_partial_rollout_preempts is not None and max_partial_rollout_preempts < 0:
@@ -1420,10 +1491,13 @@ def create_app(
                 }
             )
 
-    @app.post("/v1/chat/completions")
-    async def chat_completions(request: Request):
-        _check_auth(request)
-        body = await request.json()
+    async def _chat_completions_pipeline(request: Request, body: dict[str, Any]):
+        """Run one chat completion end to end.
+
+        Heartbeat streaming wraps this coroutine, so every outcome must stay
+        expressible as a returned response or a raised exception.
+        """
+
         messages: list[dict] = body.get("messages", [])
         model = body.get("model", "proxy-model")
         stream = bool(body.get("stream", False))
@@ -1938,6 +2012,7 @@ def create_app(
                     include_usage,
                 ),
                 media_type="text/event-stream",
+                headers=_SSE_RESPONSE_HEADERS,
             )
 
         return JSONResponse(
@@ -1951,6 +2026,96 @@ def create_app(
                 completion_tokens=public_completion_tokens,
                 response_id=response_id,
             )
+        )
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request):
+        """Run the chat completion, keeping the upstream connection warm.
+
+        ``/generate`` is not streaming, so a ``stream=true`` request would
+        otherwise send nothing until generation finished and get cut by an idle
+        gateway.  Heartbeat comment frames keep the Dressage -> blackbox hop
+        alive while generation runs.
+
+        Invariant relied upon downstream: because the response body is
+        pseudo-streamed from an already-computed result, heartbeats and the
+        terminal error event can only appear *before* the first real chunk.
+        The blackbox proxy therefore only has to drain the heartbeat prelude and
+        inspect a single frame.  Turning ``/generate`` into real token streaming
+        would break that assumption and require full-stream error sniffing.
+        """
+
+        _check_auth(request)
+        body = await request.json()
+        stream = bool(body.get("stream", False))
+
+        if not stream or stream_heartbeat_interval_seconds <= 0:
+            return await _chat_completions_pipeline(request, body)
+
+        # Keep the original HTTP status for anything that settles before the
+        # first heartbeat commits the response.
+        task = asyncio.create_task(_chat_completions_pipeline(request, body))
+        task.add_done_callback(_consume_task_exception)
+        try:
+            done, _ = await asyncio.wait(
+                {task},
+                timeout=stream_heartbeat_interval_seconds,
+            )
+        except asyncio.CancelledError:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise
+        if done:
+            return task.result()
+
+        async def _heartbeat_stream():
+            try:
+                while True:
+                    if task.done():
+                        break
+                    yield _SSE_HEARTBEAT
+                    finished, _ = await asyncio.wait(
+                        {task},
+                        timeout=stream_heartbeat_interval_seconds,
+                    )
+                    if finished:
+                        break
+                try:
+                    result = task.result()
+                except HTTPException as exc:
+                    yield _stream_error_chunk(exc.status_code, exc.detail)
+                    yield "data: [DONE]\n\n"
+                    return
+                except Exception:
+                    logger.exception("chat completion failed during heartbeat streaming")
+                    yield _stream_error_chunk(
+                        500,
+                        {
+                            "code": "internal_error",
+                            "message": "Internal proxy error.",
+                        },
+                    )
+                    yield "data: [DONE]\n\n"
+                    return
+                if not 200 <= result.status_code < 300:
+                    yield _stream_error_chunk(
+                        result.status_code, _response_json_payload(result)
+                    )
+                    yield "data: [DONE]\n\n"
+                    return
+                assert isinstance(result, StreamingResponse)
+                async for chunk in result.body_iterator:
+                    yield chunk
+            finally:
+                if not task.done():
+                    task.cancel()
+                    await asyncio.gather(task, return_exceptions=True)
+                    logger.info("chat completion client disconnected; cancelled generation")
+
+        return StreamingResponse(
+            _heartbeat_stream(),
+            media_type="text/event-stream",
+            headers=_SSE_RESPONSE_HEADERS,
         )
 
     @app.post("/session/finalize")
@@ -2245,6 +2410,9 @@ def create_app(
                 "use_rollout_routing_replay": use_rollout_routing_replay,
                 "partial_rollout": partial_rollout,
                 "max_partial_rollout_preempts": max_partial_rollout_preempts,
+                "stream_heartbeat_interval_seconds": (
+                    stream_heartbeat_interval_seconds
+                ),
             },
         }
 
@@ -2352,6 +2520,16 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Maximum model weight version switches allowed for one partial-rollout session.",
     )
+    parser.add_argument(
+        "--stream-heartbeat-interval-seconds",
+        type=_non_negative_finite_float,
+        default=_DEFAULT_STREAM_HEARTBEAT_INTERVAL_SECONDS,
+        help=(
+            "Seconds between SSE comment heartbeats for stream=true requests "
+            "while generation is still running. 0 disables heartbeats and "
+            "keeps the legacy respond-after-completion behavior."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -2384,6 +2562,7 @@ def main() -> None:
         use_rollout_routing_replay=args.use_rollout_routing_replay,
         partial_rollout=args.dressage_partial_rollout,
         max_partial_rollout_preempts=args.max_partial_rollout_preempts,
+        stream_heartbeat_interval_seconds=args.stream_heartbeat_interval_seconds,
     )
     uvicorn.run(app, host=args.host, port=args.port)
 

--- a/tests/blackbox_server/test_rollout_llm_proxy.py
+++ b/tests/blackbox_server/test_rollout_llm_proxy.py
@@ -2857,3 +2857,151 @@ def test_prelude_conversion_survives_multibyte_char_split_across_chunks():
         if name == "content_block_delta"
     )
     assert text == "ok中文"
+
+
+class _BreakingByteStream(httpx.AsyncByteStream):
+    """Yield the given chunks, then break the stream with a ReadError."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+        raise httpx.ReadError("upstream connection broke during prelude")
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _HangingByteStream(httpx.AsyncByteStream):
+    """Yield the given chunks, then hang until cancelled."""
+
+    def __init__(self, chunks: list[bytes], consumed: asyncio.Event) -> None:
+        self._chunks = chunks
+        self._consumed = consumed
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+        self._consumed.set()
+        await asyncio.Event().wait()
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _prelude_request_payload(path: str) -> dict[str, Any]:
+    payload: dict[str, Any] = {"model": "proxy-model", "stream": True}
+    if path.endswith("/messages"):
+        payload.update({"max_tokens": 1, "messages": [{"role": "user", "content": "hi"}]})
+    elif path.endswith("/responses"):
+        payload["input"] = "hi"
+    else:
+        payload["messages"] = [{"role": "user", "content": "hi"}]
+    return payload
+
+
+@pytest.mark.parametrize("path", ["/v1/chat/completions", "/v1/messages", "/v1/responses"])
+def test_prelude_upstream_break_releases_request_marker(path: str):
+    proxy = _make_proxy()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        _ = request
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=_BreakingByteStream([_HEARTBEAT]),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001", backend_session_id="session-1")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            with pytest.raises(httpx.ReadError):
+                await client.post(path, json=_prelude_request_payload(path))
+        # The break during the prelude must have released the request marker.
+        await asyncio.wait_for(proxy.drain_turn(timeout=0.5), timeout=1.0)
+        assert proxy._turn_scope is not None
+        assert proxy._turn_scope.inflight_requests == 0
+        await proxy._client.aclose()
+
+    asyncio.run(run_test())
+
+
+def test_prelude_cancellation_releases_request_marker():
+    proxy = _make_proxy()
+    consumed = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        _ = request
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=_HangingByteStream([_HEARTBEAT], consumed),
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001", backend_session_id="session-1")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            task = asyncio.create_task(
+                client.post(
+                    "/v1/chat/completions",
+                    json=_prelude_request_payload("/v1/chat/completions"),
+                )
+            )
+            await asyncio.wait_for(consumed.wait(), timeout=1.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        # Cancellation mid-prelude must have released the request marker.
+        await asyncio.wait_for(proxy.drain_turn(timeout=0.5), timeout=1.0)
+        assert proxy._turn_scope is not None
+        assert proxy._turn_scope.inflight_requests == 0
+        await proxy._client.aclose()
+
+    asyncio.run(run_test())
+
+
+@pytest.mark.parametrize("path", ["/v1/chat/completions", "/v1/messages", "/v1/responses"])
+def test_send_stream_request_cancellation_releases_request_marker(path: str):
+    proxy = _make_proxy()
+    sending = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        # Hang before returning response headers, i.e. inside the await point of
+        # _send_stream_request, which cancellation must not leave unguarded.
+        _ = request
+        sending.set()
+        await asyncio.Event().wait()
+        return httpx.Response(200)
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001", backend_session_id="session-1")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            task = asyncio.create_task(
+                client.post(path, json=_prelude_request_payload(path))
+            )
+            await asyncio.wait_for(sending.wait(), timeout=1.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        # Cancellation before the response headers arrived must have released
+        # the request marker; otherwise drain_turn() hangs at turn teardown.
+        await asyncio.wait_for(proxy.drain_turn(timeout=0.5), timeout=1.0)
+        assert proxy._turn_scope is not None
+        assert proxy._turn_scope.inflight_requests == 0
+        await proxy._client.aclose()
+
+    asyncio.run(run_test())

--- a/tests/blackbox_server/test_rollout_llm_proxy.py
+++ b/tests/blackbox_server/test_rollout_llm_proxy.py
@@ -9,6 +9,7 @@ from typing import Any
 import httpx
 import pytest
 
+from blackbox_server.adapters.base import backend_context_overflow_from_proxy_payload
 from blackbox_server.proxy.rollout_llm_proxy import RolloutLLMProxy
 
 
@@ -2578,3 +2579,281 @@ def test_rollout_proxy_recognizes_partial_staleness_invalidated_response():
     )
 
     assert recorded == payload["detail"]
+
+
+_HEARTBEAT = b": dressage-heartbeat\n\n"
+
+
+def _dressage_error_event(status_code: int, code: str) -> bytes:
+    return _sse_event(
+        {
+            "error": {
+                "type": "dressage_proxy_error",
+                "code": code,
+                "message": f"Dressage proxy {code}.",
+                "status_code": status_code,
+            }
+        }
+    )
+
+
+def _stream_through_proxy(proxy: RolloutLLMProxy, path: str, chunks: list[bytes]):
+    """Drive one streaming model request; return (status_code, body, content_type)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        _ = request
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncByteStream(chunks),
+        )
+
+    payload: dict[str, Any] = {"model": "proxy-model", "stream": True}
+    if path.endswith("/messages"):
+        payload.update({"max_tokens": 1, "messages": [{"role": "user", "content": "hi"}]})
+    elif path.endswith("/responses"):
+        payload["input"] = "hi"
+    else:
+        payload["messages"] = [{"role": "user", "content": "hi"}]
+
+    async def run_test() -> tuple[int, bytes]:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001", backend_session_id="session-1")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            async with client.stream("POST", path, json=payload) as response:
+                body = await response.aread()
+                status_code = response.status_code
+                content_type = response.headers.get("content-type")
+        await proxy.drain_turn(timeout=1.0)
+        await proxy._client.aclose()
+        return status_code, body, content_type
+
+    return asyncio.run(run_test())
+
+
+def test_prelude_drops_heartbeats_and_forwards_chat_stream_verbatim():
+    proxy = _make_proxy()
+    real_chunks = [
+        _sse_event({"id": "chatcmpl-1", "choices": [{"delta": {"role": "assistant"}}]}),
+        _sse_event({"id": "chatcmpl-1", "choices": [{"delta": {"content": "hi"}}]}),
+        b"data: [DONE]\n\n",
+    ]
+
+    status_code, body, content_type = _stream_through_proxy(
+        proxy,
+        "/v1/chat/completions",
+        [_HEARTBEAT, _HEARTBEAT, *real_chunks],
+    )
+
+    assert status_code == 200
+    assert b"dressage-heartbeat" not in body
+    assert body == b"".join(real_chunks)
+
+
+def test_prelude_drops_heartbeats_split_and_glued_across_chunks():
+    proxy = _make_proxy()
+    real_chunks = [
+        _sse_event({"id": "chatcmpl-1", "choices": [{"delta": {"content": "hi"}}]}),
+        b"data: [DONE]\n\n",
+    ]
+
+    status_code, body, content_type = _stream_through_proxy(
+        proxy,
+        "/v1/chat/completions",
+        [
+            b": dressage-",
+            b"heartbeat\n\n: dressage-heartbeat\n\n" + real_chunks[0][:10],
+            real_chunks[0][10:] + real_chunks[1],
+        ],
+    )
+
+    assert status_code == 200
+    assert b"dressage-heartbeat" not in body
+    assert body == b"".join(real_chunks)
+
+
+def test_prelude_drops_every_comment_frame_ahead_of_the_first_real_frame():
+    proxy = _make_proxy()
+
+    status_code, body, content_type = _stream_through_proxy(
+        proxy,
+        "/v1/chat/completions",
+        [_HEARTBEAT, b": other-comment\n\n", b"data: [DONE]\n\n"],
+    )
+
+    # Every comment frame ahead of the first real frame is prelude noise, so the
+    # forwarded stream starts at the first non-comment frame.
+    assert status_code == 200
+    assert b"dressage-heartbeat" not in body
+    assert b": other-comment" not in body
+    assert body == b"data: [DONE]\n\n"
+
+
+def test_prelude_restores_status_code_for_late_chat_completion_error():
+    proxy = _make_proxy()
+
+    status_code, body, content_type = _stream_through_proxy(
+        proxy,
+        "/v1/chat/completions",
+        [_HEARTBEAT, _dressage_error_event(413, "context_overflow"), b"data: [DONE]\n\n"],
+    )
+
+    async def consume() -> dict[str, Any] | None:
+        return await proxy.consume_context_overflow_error()
+
+    overflow = asyncio.run(consume())
+
+    assert status_code == 413
+    assert content_type == "application/json"
+    assert b"dressage-heartbeat" not in body
+    assert json.loads(body)["code"] == "context_overflow"
+    assert overflow is not None
+    # The marker must still convert into the typed error the adapters raise,
+    # otherwise the overflow is silently swallowed by the turn teardown.
+    assert backend_context_overflow_from_proxy_payload(overflow) is not None
+
+
+def test_prelude_restores_status_code_for_late_anthropic_error():
+    proxy = _make_proxy()
+
+    status_code, body, content_type = _stream_through_proxy(
+        proxy,
+        "/v1/messages",
+        [_HEARTBEAT, _dressage_error_event(413, "context_overflow"), b"data: [DONE]\n\n"],
+    )
+
+    # No message_start is emitted, so the agent cannot mistake the failure for a
+    # successful empty message.
+    assert status_code == 413
+    assert b"message_start" not in body
+    assert json.loads(body)["type"] == "error"
+
+
+def test_prelude_maps_late_5xx_to_non_retry_anthropic_error():
+    proxy = _make_proxy()
+
+    status_code, body, content_type = _stream_through_proxy(
+        proxy,
+        "/v1/messages",
+        [_HEARTBEAT, _dressage_error_event(502, "upstream_failure"), b"data: [DONE]\n\n"],
+    )
+
+    payload = json.loads(body)
+
+    assert status_code == 400
+    assert payload["error"]["type"] == "upstream_error"
+    assert "HTTP 502" in payload["error"]["message"]
+
+
+def test_prelude_returns_synthetic_stream_for_late_rollout_invalidation():
+    proxy = _make_proxy()
+
+    status_code, body, content_type = _stream_through_proxy(
+        proxy,
+        "/v1/chat/completions",
+        [
+            _HEARTBEAT,
+            _dressage_error_event(502, "generation_preempted"),
+            b"data: [DONE]\n\n",
+        ],
+    )
+
+    async def consume() -> dict[str, Any] | None:
+        return await proxy.consume_rollout_invalidated_error()
+
+    invalidated = asyncio.run(consume())
+
+    assert status_code == 200
+    assert b"dressage-heartbeat" not in body
+    assert b"data: [DONE]" in body
+    assert invalidated is not None
+
+
+def test_prelude_converts_heartbeated_anthropic_success_stream():
+    proxy = _make_proxy()
+
+    status_code, body, content_type = _stream_through_proxy(
+        proxy,
+        "/v1/messages",
+        [
+            _HEARTBEAT,
+            _sse_event({"model": "proxy-model", "choices": [{"delta": {"content": "hi"}}]}),
+            _sse_event({"choices": [{"delta": {}, "finish_reason": "stop"}]}),
+            b"data: [DONE]\n\n",
+        ],
+    )
+    events = _sse_events_from_body(body)
+
+    assert status_code == 200
+    assert b"dressage-heartbeat" not in body
+    assert [name for name, _ in events][0] == "message_start"
+    assert "message_stop" in [name for name, _ in events]
+
+
+def test_prelude_converts_heartbeated_openai_responses_stream():
+    proxy = _make_proxy()
+
+    status_code, body, content_type = _stream_through_proxy(
+        proxy,
+        "/v1/responses",
+        [
+            _HEARTBEAT,
+            _sse_event({"id": "chatcmpl-1", "choices": [{"delta": {"content": "hi"}}]}),
+            _sse_event({"choices": [{"delta": {}, "finish_reason": "stop"}]}),
+            b"data: [DONE]\n\n",
+        ],
+    )
+    events = _sse_events_from_body(body)
+
+    assert status_code == 200
+    assert b"dressage-heartbeat" not in body
+    assert [name for name, _ in events][0] == "response.created"
+    assert [name for name, _ in events][-1] == "response.completed"
+
+
+def test_prelude_handles_stream_that_is_only_heartbeats():
+    proxy = _make_proxy()
+
+    status_code, body, content_type = _stream_through_proxy(
+        proxy,
+        "/v1/chat/completions",
+        [_HEARTBEAT, _HEARTBEAT],
+    )
+
+    assert status_code == 200
+    assert body == b""
+
+
+def test_prelude_conversion_survives_multibyte_char_split_across_chunks():
+    proxy = _make_proxy()
+    # The split must land after the prelude handed over the first real frame,
+    # because that is the region decoded chunk by chunk.  Non-ASCII content is
+    # reachable whenever the upstream serializes with ensure_ascii=False.
+    first_frame = _sse_event({"choices": [{"delta": {"content": "ok"}}]})
+    second_frame = b'data: {"choices":[{"delta":{"content":"\xe4\xb8\xad\xe6\x96\x87"}}]}\n\n'
+    split = second_frame.index(b"\xe6\x96\x87") + 1
+
+    status_code, body, _ = _stream_through_proxy(
+        proxy,
+        "/v1/messages",
+        [
+            _HEARTBEAT,
+            first_frame,
+            second_frame[:split],
+            second_frame[split:]
+            + _sse_event({"choices": [{"delta": {}, "finish_reason": "stop"}]}),
+            b"data: [DONE]\n\n",
+        ],
+    )
+
+    assert status_code == 200
+    assert "\ufffd" not in body.decode("utf-8")
+    text = "".join(
+        payload["delta"]["text"]
+        for name, payload in _sse_events_from_body(body)
+        if name == "content_block_delta"
+    )
+    assert text == "ok中文"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -797,6 +797,7 @@ def make_client(
     use_rollout_routing_replay: bool = False,
     partial_rollout: bool = False,
     max_partial_rollout_preempts: int | None = None,
+    stream_heartbeat_interval_seconds: float | None = None,
 ):
     session_manager = SessionManager()
     trajectory_store = TrajectoryStore(min_group_size=1, group_timeout=0.0)
@@ -828,6 +829,10 @@ def make_client(
     )
     if tool_call_parser is not _UNSET:
         create_app_kwargs["tool_call_parser"] = tool_call_parser
+    if stream_heartbeat_interval_seconds is not None:
+        create_app_kwargs["stream_heartbeat_interval_seconds"] = (
+            stream_heartbeat_interval_seconds
+        )
     app = create_app(**create_app_kwargs)
     return (
         TestClient(app),
@@ -5805,3 +5810,189 @@ def test_generation_controller_shutdown_rejects_new_generations():
         raise AssertionError("Expected shutdown controller to reject generation")
 
     asyncio.run(run_test())
+
+
+def _heartbeat_app(sglang_client, *, interval: float, context_window: int | None = None):
+    return create_app(
+        sglang_router_url="http://router.test",
+        tokenizer=FakeTokenizer(),
+        session_manager=SessionManager(),
+        trajectory_store=TrajectoryStore(min_group_size=1, group_timeout=0.0),
+        sglang_client=sglang_client,
+        context_window=context_window,
+        stream_heartbeat_interval_seconds=interval,
+    )
+
+
+async def _collect_stream(app, payload: dict, *, session: str) -> tuple[int, str]:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        async with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            headers={"X-Session-Id": session, "X-Instance-Id": f"inst-{session}"},
+            json=payload,
+        ) as response:
+            body = "".join([chunk async for chunk in response.aiter_text()])
+            return response.status_code, body
+
+
+def test_stream_heartbeat_emits_keepalive_before_chunks():
+    blocking_client = BlockingSGLangClient([make_response("hello")])
+    app = _heartbeat_app(blocking_client, interval=0.05)
+
+    async def run_test() -> None:
+        collect = asyncio.create_task(
+            _collect_stream(
+                app,
+                {
+                    "model": "fake-model",
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                session="sess-hb",
+            )
+        )
+        assert await asyncio.to_thread(blocking_client.first_call_started.wait, 2.0)
+        # Let at least two heartbeat intervals elapse before generation returns.
+        await asyncio.sleep(0.2)
+        blocking_client.release_first_call.set()
+        status_code, body = await collect
+
+        assert status_code == 200
+        assert body.count(": dressage-heartbeat") >= 2
+        assert body.index(": dressage-heartbeat") < body.index("data: ")
+        assert '"role": "assistant"' in body or '"role":"assistant"' in body
+        assert body.rstrip().endswith("data: [DONE]")
+
+    asyncio.run(run_test())
+
+
+def test_stream_heartbeat_fast_completion_matches_legacy_stream():
+    payload = {
+        "model": "fake-model",
+        "stream": True,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    async def run_test() -> None:
+        with_heartbeat = await _collect_stream(
+            _heartbeat_app(FakeSGLangClient([make_response("hello")]), interval=5.0),
+            payload,
+            session="sess-hb-fast",
+        )
+        disabled = await _collect_stream(
+            _heartbeat_app(FakeSGLangClient([make_response("hello")]), interval=0.0),
+            payload,
+            session="sess-hb-off",
+        )
+
+        assert with_heartbeat[0] == disabled[0] == 200
+        assert ": dressage-heartbeat" not in with_heartbeat[1]
+        assert ": dressage-heartbeat" not in disabled[1]
+        # Response ids differ per request; compare everything else verbatim.
+        strip_id = lambda text: re.sub(r'"id": ?"chatcmpl-[0-9a-f]+"', '"id":"X"', text)
+        assert strip_id(with_heartbeat[1]) == strip_id(disabled[1])
+
+    asyncio.run(run_test())
+
+
+def test_stream_heartbeat_preserves_status_code_for_fast_errors():
+    messages = [{"role": "user", "content": "hi"}]
+    tokenizer = FakeTokenizer()
+    prompt_ids = tokenizer.apply_chat_template(
+        messages,
+        tokenize=True,
+        add_generation_prompt=True,
+        return_dict=True,
+    )["input_ids"]
+    client, _, _, sglang_client = make_client(
+        tokenizer=tokenizer,
+        sglang_client=FakeSGLangClient([make_response("a")]),
+        context_window=len(prompt_ids) + 1,
+        stream_heartbeat_interval_seconds=5.0,
+    )
+
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"X-Session-Id": "sess-hb-fast-err", "X-Instance-Id": "inst-1"},
+        json={"model": "fake-model", "stream": True, "messages": messages},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["error"] == "context_overflow"
+    assert sglang_client.calls == []
+
+
+def test_stream_heartbeat_reports_late_error_in_stream():
+    messages = [{"role": "user", "content": "hi"}]
+    tokenizer = FakeTokenizer()
+    prompt_ids = tokenizer.apply_chat_template(
+        messages,
+        tokenize=True,
+        add_generation_prompt=True,
+        return_dict=True,
+    )["input_ids"]
+    blocking_client = BlockingSGLangClient([make_response("abc")])
+    app = _heartbeat_app(
+        blocking_client,
+        interval=0.05,
+        context_window=len(prompt_ids) + 2,
+    )
+
+    async def run_test() -> None:
+        collect = asyncio.create_task(
+            _collect_stream(
+                app,
+                {
+                    "model": "fake-model",
+                    "stream": True,
+                    "messages": messages,
+                    "max_tokens": 3,
+                },
+                session="sess-hb-late-err",
+            )
+        )
+        assert await asyncio.to_thread(blocking_client.first_call_started.wait, 2.0)
+        await asyncio.sleep(0.2)
+        blocking_client.release_first_call.set()
+        status_code, body = await collect
+
+        # The heartbeat already committed HTTP 200, so the 413 is relayed inside
+        # the stream with its status code preserved for the blackbox proxy.
+        assert status_code == 200
+        assert ": dressage-heartbeat" in body
+        error_line = [
+            line for line in body.splitlines() if line.startswith("data: {")
+        ][-1]
+        error = json.loads(error_line[len("data: ") :])["error"]
+        assert error["status_code"] == 413
+        assert error["code"] == "context_overflow"
+        assert error["type"] == "dressage_proxy_error"
+        assert body.rstrip().endswith("data: [DONE]")
+
+    asyncio.run(run_test())
+
+
+@pytest.mark.parametrize("value", [-1.0, float("nan"), float("inf")])
+def test_create_app_rejects_invalid_stream_heartbeat_interval_seconds(value):
+    with pytest.raises(ValueError, match="stream_heartbeat_interval_seconds"):
+        create_app(
+            sglang_router_url="http://router.test",
+            tokenizer=FakeTokenizer(),
+            session_manager=SessionManager(),
+            trajectory_store=TrajectoryStore(min_group_size=1, group_timeout=0.0),
+            sglang_client=FakeSGLangClient([make_response("hello")]),
+            stream_heartbeat_interval_seconds=value,
+        )
+
+
+def test_health_reports_stream_heartbeat_interval():
+    client, _, _, _ = make_client(
+        make_response("hello"),
+        stream_heartbeat_interval_seconds=7.5,
+    )
+
+    config = client.get("/health").json()["config"]
+
+    assert config["stream_heartbeat_interval_seconds"] == 7.5


### PR DESCRIPTION
## Summary

Dressage's `/v1/chat/completions` is backed by SGLang's non-streaming `/generate`, so a `stream=true` request writes nothing until generation finishes. Long generations therefore look idle to the gateway on the path and get cut, aborting healthy rollouts.

This adds SSE comment heartbeats to keep the Dressage → blackbox connection warm while generation runs. `/generate` is not turned into real token streaming, and completion content, usage, tool calls and trajectory semantics are unchanged.

```mermaid
sequenceDiagram
    participant Agent
    participant Blackbox
    participant Dressage
    participant SGLang

    Agent->>Blackbox: Request with stream=true
    Blackbox->>Dressage: POST /v1/chat/completions
    Dressage->>SGLang: Non-streaming POST /generate

    loop While generation is in progress
        Dressage-->>Blackbox: SSE heartbeat comment
        Note over Blackbox: Consumed and not forwarded to Agent
    end

    SGLang-->>Dressage: Complete generation result
    Dressage-->>Blackbox: Existing pseudo-streamed SSE
    Blackbox-->>Agent: Original SSE content
```

## Highlights

**Dressage proxy** — the route body moves into `_chat_completions_pipeline` (logic unchanged) and the route wraps it:

- Settles within one interval → original response returned as-is: no heartbeat, status code unchanged.
- Slower → commits a `StreamingResponse`, emits `: dressage-heartbeat` every interval, then forwards the existing pseudo-stream body in the same event order.
- A failure after the first heartbeat can no longer use a status code, so it is relayed as a terminal SSE error event carrying `status_code`.
- Client disconnect cancels the generation task.

**Blackbox proxy** — drains the heartbeat prelude and inspects only the first real frame. The body is pseudo-streamed from an already-computed result, so a failure can only precede that frame; nothing has reached the agent yet, and the recovered error reuses the existing `>=400` path. Frames after the first are forwarded untouched.

**Configuration** — `--stream-heartbeat-interval-seconds` (default `15`, `0` disables). Negative or non-finite values are rejected at startup; the effective value is reported under `/health` → `config`.

**Cleanup on a cut-short stream** — the prelude awaits the whole generation, so an upstream break or a downstream cancellation there used to skip both the connection close and the request marker, leaving `inflight_requests` above zero and stalling `drain_turn()` at turn teardown. The prelude is now guarded, and the first guard of each streaming path was widened from `Exception` to `BaseException` since cancellation is a `BaseException`.

## Compatibility

- Backward compatible. `stream=false`, fast `stream=true` requests, and `interval=0` behave exactly as before.
- Keepalive covers the Dressage → blackbox hop only. The blackbox → agent hop is byte-for-byte unchanged: heartbeats never reach the agent, and errors are still delivered as ordinary `4xx`/`5xx` responses.
- Rollback is `--stream-heartbeat-interval-seconds 0`; the blackbox-side changes are a no-op on a stream without heartbeats and can stay in place.
- Three fixes the in-stream error event required, each of which failed silently before: context overflow and rollout invalidation are classified on `code` as well as `error` (the event renames that key, and the markers were being dropped — a failed turn was reported as successful); the recovered error response is labelled `application/json` rather than inheriting `text/event-stream`; SSE payloads are framed in the byte domain so a chunk boundary inside a multi-byte character cannot corrupt it.
- Assumption: errors can only precede the first real frame because the body is pseudo-streamed. Making `/generate` truly streaming would break prelude-only inspection and require full-stream sniffing. Documented in `chat_completions` and `_drain_keepalive_prelude`.

## Validation

Environment: single node, 8x B200 (180 GB). Local bwrap sandbox, Qwen3.5-4B,
dataset `dressage_dapo_prompts.jsonl`, `--stream-heartbeat-interval-seconds 2`.
Docker image: `huang3eng/dressage:nightly-dev-20260801a`.
Key components: Python 3.12, torch 2.9.1+cu129, SGLang 0.5.10.post1, sglang-router 0.3.2, Megatron-core 0.16.0rc0, slime 0.3.0, ray 2.55.1, transformers 5.3.0.

### Unit tests

- `tests/test_proxy.py` + `tests/test_proxy_client.py` + `tests/integrations/harbor/test_contracts.py`: 169 passed.
- `tests/blackbox_server/`: 225 passed (18 new cases covering the prelude, first-frame error sniffing, split/glued heartbeats, multi-byte UTF-8 across chunks, and marker release on a cut-short stream). The single `test_command.py` failure is environmental (`python` not on `PATH`) and reproduces on an unmodified checkout.

### End-to-end

1. **Heartbeat cadence** — Sent a long `stream=true` request via `curl` to observe the raw stream. The proxy emitted 3 heartbeats (one every 2 s) before the first real `data:` frame, then delivered the full body: content chunks → `finish_reason` → `usage` (6048 tokens) → `[DONE]`.

2. **RL training (4 backends)** — Ran async RL training with `openclaw`, `opencode`, `codex`, `claude_code`. All four completed with non-empty responses. All sample/session files contain zero `dressage-heartbeat` bytes — the blackbox proxy fully drains heartbeats before the agent. Zero `heartbeat streaming` errors and zero tracebacks in the training log. A few `rollout_invalidated` 502s appeared from the async weight-update preemption path and were retried successfully (`exhausted retries` = 0).

3. **Late 502 (rollout preemption)** — Started a long generation, waited for heartbeats, then called `POST /v1/rollout/pause`. Response stayed `HTTP/1.1 200 OK`; body: 2 heartbeats → `data: {"error":{...,"code":"generation_preempted","status_code":502}}` → `[DONE]`. BBS correctly recovers the 502 and records the `rollout_invalidated` marker.

4. **Late 413 (context overflow)** — Restarted the proxy with `--context-window 2048 --no-dynamic-max-tokens` and sent a 25-token prompt with `max_tokens=8192`. Response stayed `HTTP/1.1 200 OK`; body: 11 heartbeats → `data: {"error":{...,"phase":"input_output","code":"context_overflow","status_code":413,"details":{"input_tokens":25,"output_tokens":5291,"context_window":2048}}}` → `[DONE]`. BBS recovers the 413 and converts it to `BackendContextOverflowError`.

5. **Late 400 forced onto the slow path by lock contention** — The step-limit check (`DRESSAGE_PROXY_MAX_STEPS_PER_SESSION`) runs before generation and returns in microseconds, so it normally takes the fast path; to reach the in-stream path the test exploits `session.request_lock`, which is held for the whole generation. On a separate proxy (port 8899, `max_steps=2`, interval 2 s) one short request brought the session to one step, then request A started a long generation while request B on the same session blocked on the lock, crossed the heartbeat interval, and only hit the step-limit check after A released the lock. B stayed at `HTTP/1.1 200 OK` and delivered 14 heartbeats → `data: {"error":{...,"status_code":400}}` → `[DONE]`, while A completed normally and the warm-up request emitted zero heartbeats and began with a real `data:` frame — one run covering the fast path, the slow success path and the slow error path. 