### PR TITLE
refactor(mopd): use dedicated objective hooks

### DIFF
--- a/docs/mopd.md
+++ b/docs/mopd.md
@@ -1,4 +1,4 @@
-# Metadata-routed multi-teacher OPD
+# Metadata-routed multi-teacher MOPD
 
 Dressage MOPD trains one Megatron student from multiple frozen Megatron
 teachers on the same actor GPUs. Every teacher and the student must have the
@@ -11,11 +11,34 @@ checkpoint is loaded once and copied into Slime's existing pinned-CPU
 that teacher's subset, and then restores the student before training. GPU model
 memory is reused; CPU memory grows with the number of teachers.
 
+## Objective
+
+For each response token sampled on-policy from the student, Dressage computes
+the stopped-gradient advantage
+
+```text
+A_t = clip(log pi_teacher(y_t) - log pi_student_old(y_t), -5, 5)
+```
+
+and minimizes the direct policy-gradient loss
+
+```text
+L = -mean(A_t * log pi_student_current(y_t)).
+```
+
+This is the paper-standard MOPD objective. Environment reward remains
+available for monitoring, but is not read by the advantage or loss. There is
+no GRPO return, PPO ratio/clipping, value target, entropy bonus, or additive
+AT-KL/OPD term. The public launcher fails closed on N greater than one and on
+options that are incompatible with the dedicated MOPD objective.
+
 ## Experiment snapshot
 
-The figure below shows a 20-step MOPD run on ALFWorld and HotpotQA with seed
-1234. Dark lines are centered five-step rolling means, and light lines are raw
-step values.
+The figure below is a historical 20-step run on ALFWorld and HotpotQA with seed
+1234. It is retained as a routing and systems snapshot; its objective metrics
+are not directly comparable with the dedicated MOPD path documented below.
+Dark lines are centered five-step rolling means, and light lines are raw step
+values.
 
 ![MOPD open training dynamics](../assets/mopd_open_dynamics_8panel.png)
 
@@ -41,7 +64,7 @@ The implementation uses:
 - upstream `create_training_models(..., actor_cls=...)` to install the
   Dressage-owned rotating actor without monkey-patching a Slime module;
 - Slime's `TensorBackuper`, checkpoint loader, `compute_log_prob`, DP
-  partitioning, and OPD loss.
+  partitioning, and custom advantage/loss hooks.
 
 The small `dressage.training.mopd_train` driver mirrors upstream `train.py`
 because upstream exposes `actor_cls` at the model factory but not yet on the
@@ -79,20 +102,22 @@ For every DP-local batch:
 3. Restore that teacher from pinned CPU memory to the shared model buffers.
 4. Compute response-token log-probabilities only for its routed samples.
 5. Repeat for other distinct teachers and scatter results to original order.
-6. Restore the student/old actor.
-7. Let stock Slime compute student log-probs, OPD advantages, backward, and the
-   optimizer step.
+6. Restore the student/old actor and compute its response-token log-probability.
+7. Compute the stopped teacher-minus-old-student advantage and apply the direct
+   `-A_t * log pi_student_current` loss.
 
-The launcher intentionally uses:
+The launcher intentionally uses Dressage's custom objective hooks:
 
 ```text
---use-opd --opd-type megatron --opd-teacher-load <first-teacher>
+--loss-type custom_loss
+--custom-advantage-function-path dressage.training.mopd_loss.compute_mopd_advantages
+--custom-loss-function-path dressage.training.mopd_loss.mopd_policy_loss
 ```
 
-The first teacher path satisfies Slime's stock argument validation and tells
-the actor factory that an OPD teacher is needed. `MOPDMegatronTrainRayActor`
-suppresses the stock single-teacher load and loads all configured named
-teachers instead.
+`MOPDMegatronTrainRayActor` loads all configured named teachers independently
+of Slime's generic `--use-opd` switch. The MOPD entrypoint labels the running
+estimator `mopd` after upstream argument parsing; no Slime source patch is
+required.
 
 ## Launch
 
@@ -102,8 +127,8 @@ export DRESSAGE_MOPD_TEACHER_CONFIG=/path/to/mopd.json
 TP_SIZE=4 \
 CP_SIZE=1 \
 ROLLOUT_BATCH_SIZE=16 \
-N_SAMPLES_PER_PROMPT=8 \
-GLOBAL_BATCH_SIZE=128 \
+N_SAMPLES_PER_PROMPT=1 \
+GLOBAL_BATCH_SIZE=16 \
 bash examples/scripts/run_mopd_qwen3.5_sync.sh
 ```
 
@@ -116,8 +141,10 @@ WANDB_GROUP=mopd-alfworld-hotpotqa \
 bash examples/scripts/run_mopd_qwen3.5_sync.sh
 ```
 
-In addition to Slime's global training metrics, Dressage logs per-teacher
-trainable-trajectory reward and sampled-token reverse-KL curves under
+In addition to Slime's global training metrics, Dressage logs the direct loss,
+sampled-token reverse-KL estimate, advantage statistics, and within-update KL
+under `train/mopd_*`. It also logs per-teacher trainable-trajectory reward and
+sampled-token reverse-KL curves under
 `rollout/mopd/raw_reward_trainable_trajectory_mean/<teacher_id>` and
 `rollout/mopd/opd_reverse_kl_train_aggregation_mean/<teacher_id>`.
 `SEED` and `ROLLOUT_SEED` are forwarded explicitly by the launcher.

--- a/dressage/rollout/convert_samples.py
+++ b/dressage/rollout/convert_samples.py
@@ -248,13 +248,6 @@ def convert_samples_to_train_data(args: Any, samples: list) -> dict:
     if tq_remote_fields:
         train_data["prompt"] = tq_layouts
     elif config_path:
-        if (
-            not bool(getattr(args, "use_opd", False))
-            or getattr(args, "opd_type", None) != "megatron"
-        ):
-            raise ValueError(
-                "MOPD train conversion requires --use-opd --opd-type megatron"
-            )
         from dressage.rollout.mopd import (
             collect_mopd_teacher_ids,
             load_mopd_config,

--- a/dressage/training/mopd_loss.py
+++ b/dressage/training/mopd_loss.py
@@ -1,0 +1,186 @@
+"""Paper-standard on-policy distillation objective for Dressage MOPD.
+
+For student-sampled response tokens, the stopped-gradient advantage is
+
+    A_t = clip(log pi_teacher(y_t) - log pi_student_old(y_t), -c, c)
+
+and the actor minimizes
+
+    L = -mean(A_t * log pi_student(y_t)).
+
+Environment rewards are deliberately absent from both equations. They may
+still be present in rollout data for monitoring and dataset diagnostics.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+MOPD_ADVANTAGE_FUNCTION_PATH = "dressage.training.mopd_loss.compute_mopd_advantages"
+MOPD_LOSS_FUNCTION_PATH = "dressage.training.mopd_loss.mopd_policy_loss"
+
+
+def _require_aligned_log_probs(
+    rollout_data: dict[str, Any],
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    student_log_probs = rollout_data.get("log_probs")
+    teacher_log_probs = rollout_data.get("teacher_log_probs")
+    if not student_log_probs:
+        raise ValueError("pure MOPD requires train-side student log_probs")
+    if not teacher_log_probs:
+        raise ValueError("pure MOPD requires routed teacher_log_probs")
+    if len(student_log_probs) != len(teacher_log_probs):
+        raise ValueError(
+            "MOPD log-prob sample count mismatch: "
+            f"student={len(student_log_probs)} teacher={len(teacher_log_probs)}"
+        )
+    for index, (student, teacher) in enumerate(
+        zip(student_log_probs, teacher_log_probs, strict=True)
+    ):
+        if student.shape != teacher.shape:
+            raise ValueError(
+                f"MOPD log-prob shape mismatch at sample {index}: "
+                f"student={tuple(student.shape)} teacher={tuple(teacher.shape)}"
+            )
+    return student_log_probs, teacher_log_probs
+
+
+def compute_mopd_advantages(args: Namespace, rollout_data: dict[str, Any]) -> None:
+    """Populate pure MOPD advantages without reading environment rewards."""
+    student_log_probs, teacher_log_probs = _require_aligned_log_probs(rollout_data)
+    clip = float(args.mopd_advantage_clip)
+    if clip <= 0:
+        raise ValueError(f"--mopd-advantage-clip must be positive; got {clip}")
+
+    advantages: list[torch.Tensor] = []
+    reverse_kls: list[torch.Tensor] = []
+    for student, teacher in zip(student_log_probs, teacher_log_probs, strict=True):
+        teacher = teacher.to(device=student.device, dtype=student.dtype)
+        reverse_kl = (student - teacher).detach()
+        advantages.append((-reverse_kl).clamp(min=-clip, max=clip).detach())
+        reverse_kls.append(reverse_kl)
+
+    rollout_data["advantages"] = advantages
+    # MOPD has no value target. Slime expects returns to exist, so retain a
+    # detached copy of the policy-gradient signal rather than an RL return.
+    rollout_data["returns"] = [advantage.clone() for advantage in advantages]
+    rollout_data["opd_reverse_kl"] = reverse_kls
+
+
+def mopd_policy_loss(
+    args: Namespace,
+    batch: dict[str, Any],
+    logits: torch.Tensor,
+    sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Compute ``-stopgrad(A_mopd) * log pi_student`` exactly."""
+    # Import lazily so the objective remains unit-testable without initializing
+    # Megatron's model stack.
+    from slime.backends.megatron_utils.loss import (
+        get_log_probs_and_entropy,
+        get_rollout_top_p_logprob_kwargs,
+    )
+
+    advantages = torch.cat(batch["advantages"], dim=0).detach()
+    old_log_probs = torch.cat(batch["log_probs"], dim=0).detach()
+    teacher_log_probs = torch.cat(batch["teacher_log_probs"], dim=0).detach()
+
+    _, log_probs_and_entropy = get_log_probs_and_entropy(
+        logits,
+        args=args,
+        unconcat_tokens=batch["unconcat_tokens"],
+        total_lengths=batch["total_lengths"],
+        response_lengths=batch["response_lengths"],
+        with_entropy=True,
+        **get_rollout_top_p_logprob_kwargs(args, batch),
+    )
+    log_probs = torch.cat(log_probs_and_entropy["log_probs"], dim=0)
+    entropy = torch.cat(log_probs_and_entropy["entropy"], dim=0)
+
+    if not (
+        advantages.shape
+        == old_log_probs.shape
+        == teacher_log_probs.shape
+        == log_probs.shape
+    ):
+        raise ValueError(
+            "MOPD loss tensors must be response-token aligned: "
+            f"advantage={tuple(advantages.shape)} old={tuple(old_log_probs.shape)} "
+            f"teacher={tuple(teacher_log_probs.shape)} current={tuple(log_probs.shape)}"
+        )
+
+    token_loss = -advantages * log_probs
+    loss = sum_of_sample_mean(token_loss)
+    if log_probs.numel() == 0:
+        loss = loss + 0 * logits.sum()
+
+    raw_teacher_gap = teacher_log_probs - old_log_probs
+    clip = float(args.mopd_advantage_clip)
+    metrics = {
+        "loss": loss.detach().clone(),
+        "mopd_loss": loss.detach().clone(),
+        "entropy": sum_of_sample_mean(entropy).detach().clone(),
+        # Sampled-token reverse-KL estimator: log pi_student - log pi_teacher.
+        "mopd_reverse_kl": sum_of_sample_mean(-raw_teacher_gap).detach().clone(),
+        "mopd_advantage": sum_of_sample_mean(advantages).detach().clone(),
+        "mopd_advantage_abs": sum_of_sample_mean(advantages.abs()).detach().clone(),
+        "mopd_advantage_clipfrac": sum_of_sample_mean(
+            (raw_teacher_gap.abs() > clip).to(dtype=log_probs.dtype)
+        )
+        .detach()
+        .clone(),
+        # Optimizer drift within this update, not teacher KL.
+        "mopd_update_kl": sum_of_sample_mean(old_log_probs - log_probs)
+        .detach()
+        .clone(),
+    }
+    return loss, metrics
+
+
+def validate_pure_mopd_args(args: Namespace) -> None:
+    """Reject options that are incompatible with the dedicated MOPD path."""
+    errors: list[str] = []
+    if args.advantage_estimator != "mopd":
+        errors.append("the MOPD entrypoint must select the pure mopd estimator")
+    if args.loss_type != "custom_loss":
+        errors.append("--loss-type must be custom_loss")
+    if args.custom_advantage_function_path != MOPD_ADVANTAGE_FUNCTION_PATH:
+        errors.append(
+            "--custom-advantage-function-path must select the Dressage pure-MOPD function"
+        )
+    if args.custom_loss_function_path != MOPD_LOSS_FUNCTION_PATH:
+        errors.append(
+            "--custom-loss-function-path must select the Dressage pure-MOPD loss"
+        )
+    if bool(args.use_opd):
+        errors.append("--use-opd must be disabled for the dedicated MOPD objective")
+    if float(args.kl_coef) != 0.0:
+        errors.append("--kl-coef must be 0")
+    if bool(args.use_kl_loss) or float(args.kl_loss_coef) != 0.0:
+        errors.append("auxiliary KL loss must be disabled")
+    if float(args.entropy_coef) != 0.0:
+        errors.append("--entropy-coef must be 0")
+    if bool(args.normalize_advantages):
+        errors.append("--normalize-advantages must be disabled")
+    if bool(args.rewards_normalization):
+        errors.append("reward normalization must be disabled")
+    if bool(args.use_critic):
+        errors.append("critic/value training must be disabled")
+    if not bool(args.compute_advantages_and_returns):
+        errors.append("advantage computation must be enabled")
+    if bool(args.use_rollout_logprobs):
+        errors.append("--use-rollout-logprobs must be disabled")
+    if bool(args.use_tis) or bool(args.use_opsm):
+        errors.append("TIS/OPSM off-policy correction must be disabled")
+    if int(args.num_steps_per_rollout) != 1:
+        errors.append("--num-steps-per-rollout must be 1")
+    if int(args.n_samples_per_prompt) != 1:
+        errors.append("--n-samples-per-prompt must be 1 for paper-standard MOPD")
+    if float(args.mopd_advantage_clip) <= 0:
+        errors.append("--mopd-advantage-clip must be positive")
+    if errors:
+        raise ValueError("invalid pure MOPD configuration:\n- " + "\n- ".join(errors))

--- a/dressage/training/mopd_megatron_actor.py
+++ b/dressage/training/mopd_megatron_actor.py
@@ -1,13 +1,17 @@
-"""Dressage-owned multi-teacher extension for slime's Megatron OPD actor.
+"""Dressage-owned routed-teacher scorer for paper-standard MOPD.
 
 The upstream actor already knows how to load a Megatron teacher, switch model
-weights, compute response-token log-probabilities, and apply the OPD loss.  This
-subclass only adds the missing multi-teacher policy:
+weights and compute response-token log-probabilities. This subclass adds the
+missing multi-teacher policy:
 
 * load the configured frozen teachers into the existing pinned-CPU weight backuper;
 * partition each local DP batch by its routed teacher;
 * score only that teacher's samples; and
 * scatter the response-aligned log-probabilities back to batch order.
+
+The pure MOPD advantage and direct policy loss live in
+``dressage.training.mopd_loss``. Slime's additive ``--use-opd`` path is
+intentionally disabled.
 
 Keeping this class in Dressage prevents slime from depending on Dressage's
 configuration schema or hard-coding MOPD route names.
@@ -132,7 +136,7 @@ def build_teacher_subset(
 
 
 class MOPDMegatronTrainRayActor(MegatronTrainRayActor):
-    """Megatron actor that extends stock single-teacher OPD to routed teachers."""
+    """Megatron actor that scores every sample with its routed frozen teacher."""
 
     def init(
         self,
@@ -149,11 +153,11 @@ class MOPDMegatronTrainRayActor(MegatronTrainRayActor):
             with_ref=with_ref,
             with_opd_teacher=False,
         )
-        if args.debug_rollout_only or role != "actor" or not with_opd_teacher:
+        if args.debug_rollout_only or role != "actor":
             return start_rollout_id
 
-        # Slime invokes this hook after OPD advantages are available and before
-        # its normal rollout-data logging. Chain any caller-provided hook.
+        # Slime invokes this hook after the custom MOPD advantages are available
+        # and before its normal rollout-data logging. Chain any caller hook.
         self._base_rollout_data_postprocess = self.rollout_data_postprocess
         self.rollout_data_postprocess = self._postprocess_mopd_metrics
         self._active_mopd_teacher_ids: list[str] | None = None

--- a/dressage/training/mopd_train.py
+++ b/dressage/training/mopd_train.py
@@ -1,8 +1,9 @@
 """Slime train loop using its native ``actor_cls`` factory hook for MOPD.
 
-The loop intentionally mirrors upstream ``slime/train.py``. The only semantic
-delta is passing ``MOPDMegatronTrainRayActor`` to
-``create_training_models(..., actor_cls=...)``. No Slime module is patched.
+The loop intentionally mirrors upstream ``slime/train.py``. The semantic
+deltas are selecting and validating the pure-MOPD objective, then passing
+``MOPDMegatronTrainRayActor`` to ``create_training_models(..., actor_cls=...)``.
+No Slime module is patched.
 """
 
 from __future__ import annotations
@@ -19,9 +20,40 @@ from slime.utils.logging_utils import configure_logger, finish_tracking, init_tr
 from slime.utils.misc import should_run_periodic_action
 
 from dressage.training.mopd_megatron_actor import MOPDMegatronTrainRayActor
+from dressage.training.mopd_loss import validate_pure_mopd_args
+
+
+def add_mopd_arguments(parser):
+    """Add Dressage-owned pure-MOPD options to Slime's parser."""
+    parser.add_argument(
+        "--mopd-advantage-clip",
+        type=float,
+        default=5.0,
+        help="Symmetric token-advantage clip for pure MOPD. Default: 5.0.",
+    )
+    return parser
+
+
+def parse_mopd_args():
+    """Parse Slime arguments and assign the dedicated MOPD identity.
+
+    Slime validates the parser's built-in estimator choices before invoking a
+    custom-advantage hook. The MOPD entrypoint keeps that parser contract, then
+    assigns ``mopd`` before rollout conversion and training. The custom hook
+    handles the objective before built-in estimator dispatch.
+    """
+    args = parse_args(add_mopd_arguments)
+    if args.advantage_estimator != "grpo":
+        raise ValueError(
+            "dressage.training.mopd_train owns the estimator; do not pass "
+            "--advantage-estimator"
+        )
+    args.advantage_estimator = "mopd"
+    return args
 
 
 def train(args) -> None:
+    validate_pure_mopd_args(args)
     configure_logger()
     release_train = args.release_train
 
@@ -117,7 +149,7 @@ def train(args) -> None:
 
 
 def main() -> None:
-    train(parse_args())
+    train(parse_mopd_args())
 
 
 if __name__ == "__main__":

--- a/examples/scripts/run_mopd_qwen3.5_sync.sh
+++ b/examples/scripts/run_mopd_qwen3.5_sync.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Same-base multi-teacher OPD with mixed blackbox/whitebox rollouts.
+# Paper-standard multi-teacher on-policy distillation (MOPD).
 #
 # Dataset routes, teacher checkpoints, reward modules, and task worker env keys
 # come from DRESSAGE_MOPD_TEACHER_CONFIG. Platform setup and credentials remain
@@ -173,19 +173,47 @@ export DRESSAGE_ALLOW_EMPTY_TRAIN_BATCH="${DRESSAGE_ALLOW_EMPTY_TRAIN_BATCH:-0}"
 export DRESSAGE_SYNC_FAILED_GROUP_REPLACEMENT_MULTIPLIER="${DRESSAGE_SYNC_FAILED_GROUP_REPLACEMENT_MULTIPLIER:-2}"
 : "${DRESSAGE_REWARD_MODULES:?MOPD config must declare reward_modules or set DRESSAGE_REWARD_MODULES}"
 
-MOPD_ARGS=(
-  --use-opd
-  --opd-type megatron
-  --opd-kl-coef "${OPD_KL_COEF:-0.1}"
-  --opd-teacher-load "${MOPD_LAUNCH_CONFIG[5]}"
-)
-if [[ -n "${MOPD_LAUNCH_CONFIG[6]:-}" ]]; then
-  MOPD_ARGS+=(--opd-teacher-ckpt-step "${MOPD_LAUNCH_CONFIG[6]}")
+N_SAMPLES_PER_PROMPT="${N_SAMPLES_PER_PROMPT:-1}"
+NUM_STEPS_PER_ROLLOUT="${NUM_STEPS_PER_ROLLOUT:-1}"
+ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-16}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-${ROLLOUT_BATCH_SIZE}}"
+MOPD_ADVANTAGE_CLIP="${MOPD_ADVANTAGE_CLIP:-5.0}"
+if [[ "${N_SAMPLES_PER_PROMPT}" != "1" ]]; then
+  echo "Paper-standard MOPD requires N_SAMPLES_PER_PROMPT=1; got ${N_SAMPLES_PER_PROMPT}." >&2
+  exit 1
 fi
+if [[ "${NUM_STEPS_PER_ROLLOUT}" != "1" ]]; then
+  echo "Paper-standard MOPD requires NUM_STEPS_PER_ROLLOUT=1; got ${NUM_STEPS_PER_ROLLOUT}." >&2
+  exit 1
+fi
+if [[ "${GLOBAL_BATCH_SIZE}" != "${ROLLOUT_BATCH_SIZE}" ]]; then
+  echo "Paper-standard MOPD requires GLOBAL_BATCH_SIZE=ROLLOUT_BATCH_SIZE; got ${GLOBAL_BATCH_SIZE} != ${ROLLOUT_BATCH_SIZE}." >&2
+  exit 1
+fi
+if [[ -n "${OPD_KL_COEF:-}" ]]; then
+  echo "OPD_KL_COEF is not used by the dedicated MOPD objective; unset it." >&2
+  exit 1
+fi
+if [[ "${NORMALIZE_ADVANTAGES:-0}" == "1" || "${USE_TIS:-0}" == "1" || "${USE_KL_LOSS:-0}" == "1" ]]; then
+  echo "Pure MOPD forbids advantage normalization, TIS, and auxiliary KL loss." >&2
+  exit 1
+fi
+if [[ "${ENTROPY_COEF:-0.0}" != "0" && "${ENTROPY_COEF:-0.0}" != "0.0" ]]; then
+  echo "Pure MOPD requires ENTROPY_COEF=0; got ${ENTROPY_COEF}." >&2
+  exit 1
+fi
+
+PURE_MOPD_ARGS=(
+  --mopd-advantage-clip "${MOPD_ADVANTAGE_CLIP}"
+  --loss-type custom_loss
+  --custom-advantage-function-path dressage.training.mopd_loss.compute_mopd_advantages
+  --custom-loss-function-path dressage.training.mopd_loss.mopd_policy_loss
+  --disable-rewards-normalization
+)
 
 echo "effective_parallelism: total_actor_gpus=${TOTAL_ACTOR_GPUS} TP_SIZE=${TP_SIZE} CP_SIZE=${CP_SIZE} DP_SIZE=${DP_SIZE} CONTEXT_WINDOW=${CONTEXT_WINDOW} ROLLOUT_MAX_CONTEXT_LEN=${ROLLOUT_MAX_CONTEXT_LEN}"
 echo "effective_blackbox: provider=${DRESSAGE_SANDBOX_PROVIDER} proxy=${DRESSAGE_PROXY_URL} backend_timeout=${DRESSAGE_BLACKBOX_BACKEND_TIMEOUT} max_steps=${DRESSAGE_BLACKBOX_MAX_STEPS} compact_threshold=${DRESSAGE_BLACKBOX_COMPACT_THRESHOLD}"
-echo "effective_mopd: teacher_config=${DRESSAGE_MOPD_TEACHER_CONFIG} modes=${MOPD_LAUNCH_CONFIG[1]:-legacy} opd_kl_coef=${OPD_KL_COEF:-0.1}"
+echo "effective_mopd: objective=pure teacher_config=${DRESSAGE_MOPD_TEACHER_CONFIG} modes=${MOPD_LAUNCH_CONFIG[1]:-legacy} advantage=clip(teacher_logp-student_old_logp,+/-${MOPD_ADVANTAGE_CLIP}) loss=-advantage*student_current_logp env_reward=monitor_only"
 
 TOKENIZER_PATH="${TOKENIZER_PATH:-${MODEL_ROOT}/${MODEL_NAME}}"
 PROXY_ARGS=(
@@ -231,14 +259,14 @@ ROLLOUT_ARGS=(
   --metadata-key metadata
   --rollout-shuffle
   --num-rollout "${NUM_ROLLOUT:-500}"
-  --rollout-batch-size "${ROLLOUT_BATCH_SIZE:-16}"
-  --n-samples-per-prompt "${N_SAMPLES_PER_PROMPT:-8}"
+  --rollout-batch-size "${ROLLOUT_BATCH_SIZE}"
+  --n-samples-per-prompt "${N_SAMPLES_PER_PROMPT}"
   --rollout-max-response-len "${ROLLOUT_MAX_RESPONSE_LEN}"
   --rollout-max-context-len "${ROLLOUT_MAX_CONTEXT_LEN}"
   --rollout-temperature "${ROLLOUT_TEMPERATURE:-1.0}"
   --rollout-seed "${ROLLOUT_SEED:-42}"
-  --num-steps-per-rollout "${NUM_STEPS_PER_ROLLOUT:-1}"
-  --global-batch-size "${GLOBAL_BATCH_SIZE:-128}"
+  --num-steps-per-rollout "${NUM_STEPS_PER_ROLLOUT}"
+  --global-batch-size "${GLOBAL_BATCH_SIZE}"
   --balance-data
   --rollout-global-dataset
 )
@@ -257,26 +285,6 @@ PERF_ARGS=(
   --max-tokens-per-gpu "${MAX_TOKENS_PER_GPU}"
   --log-probs-chunk-size "${LOG_PROBS_CHUNK_SIZE:-1024}"
 )
-
-GRPO_ARGS=(
-  --advantage-estimator grpo
-  --entropy-coef "${ENTROPY_COEF:-0.0}"
-  --eps-clip "${EPS_CLIP:-0.2}"
-  --eps-clip-high "${EPS_CLIP_HIGH:-0.28}"
-)
-if [[ "${NORMALIZE_ADVANTAGES:-0}" == "1" ]]; then
-  GRPO_ARGS+=(--normalize-advantages)
-fi
-if [[ "${USE_TIS:-0}" == "1" ]]; then
-  GRPO_ARGS+=(--use-tis)
-fi
-if [[ "${USE_KL_LOSS:-0}" == "1" ]]; then
-  GRPO_ARGS+=(
-    --use-kl-loss
-    --kl-loss-coef "${KL_LOSS_COEF:-0.001}"
-    --kl-loss-type "${KL_LOSS_TYPE:-low_var_kl}"
-  )
-fi
 
 OPTIMIZER_ARGS=(
   --optimizer adam
@@ -344,6 +352,9 @@ if [[ "${MOPD_LAUNCH_DRY_RUN:-0}" == "1" ]]; then
   echo "effective_model=${MODEL_ROOT}/${MODEL_NAME} model_config=${MODEL_CONFIG}"
   echo "effective_runtime_env_keys=${DRESSAGE_EXTRA_RUNTIME_ENV_KEYS:-none}"
   echo "effective_reward_modules=${DRESSAGE_REWARD_MODULES}"
+  printf 'effective_pure_mopd_args='
+  printf ' %q' "${PURE_MOPD_ARGS[@]}"
+  printf '\n'
   exit 0
 fi
 
@@ -487,9 +498,8 @@ ray job submit --address="http://127.0.0.1:${RAY_DASHBOARD_PORT}" \
   "${CKPT_ARGS[@]}" \
   "${ROLLOUT_ARGS[@]}" \
   "${OPTIMIZER_ARGS[@]}" \
-  "${GRPO_ARGS[@]}" \
+  "${PURE_MOPD_ARGS[@]}" \
   "${WANDB_ARGS[@]}" \
   "${PERF_ARGS[@]}" \
   "${SGLANG_ARGS[@]}" \
-  "${MOPD_ARGS[@]}" \
   "${MISC_ARGS[@]}"

--- a/tests/test_convert_samples_multi_segment.py
+++ b/tests/test_convert_samples_multi_segment.py
@@ -7,6 +7,7 @@ fallback, plus end-to-end ``convert_samples_to_train_data``.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from enum import Enum
 from types import SimpleNamespace
@@ -349,6 +350,24 @@ def test_convert_samples_trajectory_equal_when_non_grpo_estimator():
     train_data = cs.convert_samples_to_train_data(args, [s1, s2])
     # trajectory-equal: rollout 7 total mask = 2+1 = 3
     assert train_data["rollout_mask_sums"] == [3, 3]
+
+
+def test_convert_samples_routes_pure_mopd_without_additive_opd(tmp_path):
+    config_path = tmp_path / "mopd.json"
+    config_path.write_text(
+        json.dumps({"teachers": {"a": {"load": "/checkpoint/a"}}}),
+        encoding="utf-8",
+    )
+    args = _traj_equal_args()
+    args.advantage_estimator = "mopd"
+    args.n_samples_per_prompt = 1
+    args.mopd_teacher_config = str(config_path)
+    sample = _real_seg(ptid="t1", instance_id="p1", mask=[1, 1], index=0, rollout_id=7)
+    sample.metadata["teacher_id"] = "a"
+
+    train_data = cs.convert_samples_to_train_data(args, [sample])
+
+    assert train_data["prompt"] == ["a"]
 
 
 def test_aborted_no_grad_sample_passes_convert_samples():

--- a/tests/test_mopd_loss.py
+++ b/tests/test_mopd_loss.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from dressage.training.mopd_loss import (
+    MOPD_ADVANTAGE_FUNCTION_PATH,
+    MOPD_LOSS_FUNCTION_PATH,
+    compute_mopd_advantages,
+    mopd_policy_loss,
+    validate_pure_mopd_args,
+)
+
+
+def _pure_args(**overrides):
+    values = {
+        "advantage_estimator": "mopd",
+        "loss_type": "custom_loss",
+        "custom_advantage_function_path": MOPD_ADVANTAGE_FUNCTION_PATH,
+        "custom_loss_function_path": MOPD_LOSS_FUNCTION_PATH,
+        "use_opd": False,
+        "kl_coef": 0.0,
+        "use_kl_loss": False,
+        "kl_loss_coef": 0.0,
+        "entropy_coef": 0.0,
+        "normalize_advantages": False,
+        "rewards_normalization": False,
+        "use_critic": False,
+        "compute_advantages_and_returns": True,
+        "use_rollout_logprobs": False,
+        "use_tis": False,
+        "use_opsm": False,
+        "num_steps_per_rollout": 1,
+        "n_samples_per_prompt": 1,
+        "mopd_advantage_clip": 5.0,
+        "rollout_top_p": 1.0,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_mopd_advantage_is_teacher_minus_student_clipped_and_reward_free():
+    args = _pure_args(mopd_advantage_clip=2.0)
+    first = {
+        "log_probs": [torch.tensor([-2.0, -1.0, -3.0])],
+        "teacher_log_probs": [torch.tensor([-1.5, -4.0, 1.0])],
+        "rewards": [12345.0],
+    }
+    second = {
+        "log_probs": [first["log_probs"][0].clone()],
+        "teacher_log_probs": [first["teacher_log_probs"][0].clone()],
+        "rewards": [-99999.0],
+    }
+
+    compute_mopd_advantages(args, first)
+    compute_mopd_advantages(args, second)
+
+    expected = torch.tensor([0.5, -2.0, 2.0])
+    torch.testing.assert_close(first["advantages"][0], expected)
+    torch.testing.assert_close(second["advantages"][0], expected)
+    torch.testing.assert_close(
+        first["opd_reverse_kl"][0], torch.tensor([-0.5, 3.0, -4.0])
+    )
+    assert not first["advantages"][0].requires_grad
+
+
+def test_mopd_loss_is_direct_logprob_loss_without_ppo_ratio(monkeypatch):
+    current_log_probs = torch.tensor([-1.2, -2.5], requires_grad=True)
+    fake_loss_module = types.ModuleType("slime.backends.megatron_utils.loss")
+    fake_loss_module.get_log_probs_and_entropy = lambda *args, **kwargs: (
+        None,
+        {
+            "log_probs": [current_log_probs],
+            "entropy": [torch.tensor([0.7, 0.9])],
+        },
+    )
+    fake_loss_module.get_rollout_top_p_logprob_kwargs = lambda *args, **kwargs: {}
+    monkeypatch.setitem(
+        sys.modules, "slime.backends.megatron_utils.loss", fake_loss_module
+    )
+
+    advantages = torch.tensor([0.5, -1.5])
+    batch = {
+        "advantages": [advantages],
+        "log_probs": [torch.tensor([-1.0, -2.0])],
+        "teacher_log_probs": [torch.tensor([-0.5, -3.5])],
+        "unconcat_tokens": [],
+        "total_lengths": [],
+        "response_lengths": [],
+    }
+    loss, metrics = mopd_policy_loss(
+        _pure_args(), batch, torch.empty(0), lambda tensor: tensor.mean()
+    )
+
+    expected = -(advantages * current_log_probs).mean()
+    torch.testing.assert_close(loss, expected)
+    loss.backward()
+    torch.testing.assert_close(current_log_probs.grad, -advantages / 2)
+    assert "pg_clipfrac" not in metrics
+
+
+def test_pure_mopd_validation_rejects_incompatible_options():
+    validate_pure_mopd_args(_pure_args())
+
+    with pytest.raises(ValueError, match="--use-opd must be disabled"):
+        validate_pure_mopd_args(_pure_args(use_opd=True))
+    with pytest.raises(ValueError, match="--n-samples-per-prompt must be 1"):
+        validate_pure_mopd_args(_pure_args(n_samples_per_prompt=4))
+    with pytest.raises(ValueError, match="reward normalization must be disabled"):
+        validate_pure_mopd_args(_pure_args(rewards_normalization=True))
+
+
+def test_public_launcher_selects_only_the_pure_objective():
+    launcher = (
+        Path(__file__).resolve().parents[1]
+        / "examples/scripts/run_mopd_qwen3.5_sync.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "dressage.training.mopd_loss.compute_mopd_advantages" in launcher
+    assert "dressage.training.mopd_loss.mopd_policy_loss" in launcher
+    assert 'N_SAMPLES_PER_PROMPT="${N_SAMPLES_PER_PROMPT:-1}"' in launcher
+    assert 'GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-${ROLLOUT_BATCH_SIZE}}"' in launcher
+    assert '"${GLOBAL_BATCH_SIZE}" != "${ROLLOUT_BATCH_SIZE}"' in launcher
+    assert "--use-opd" not in launcher
+    assert "--opd-kl-coef" not in launcher
+    assert "--advantage-estimator grpo" not in launcher
+    assert "--eps-clip" not in launcher


### PR DESCRIPTION
# Proposed title

`fix(mopd): align training with the dedicated MOPD objective`

# Proposed body

## Motivation

The previous MOPD training path coupled routed teacher scoring to Slime's
generic `--use-opd` switch and combined the reward-derived GRPO objective with
an additive OPD term. That does not implement MOPD as a standalone on-policy
distillation objective.

## What changed

- Add Dressage-owned advantage and loss hooks for paper-standard MOPD:

  ```text
  A = stopgrad(clip(logp_teacher - logp_student_old, -5, 5))
  L = -mean(A * logp_student_current)
  ```

- Keep environment reward for monitoring only; it is not used by the MOPD
  objective.
- Load and route frozen teachers independently of Slime's generic OPD path.
- Add a dedicated MOPD training entrypoint and fail closed on incompatible
  options, including `N != 1`, multiple optimizer steps per rollout, reward
  normalization, TIS, auxiliary KL, and entropy terms.
- Preserve response-token alignment for multi-segment converted samples.
- Update the launcher and MOPD documentation.
- Keep the Slime submodule unchanged.

## Test report

### Source under test

- Base image: `huang3eng/dressage:latest`, freshly resolved on 2026-08-19 to
  manifest `sha256:c7f28d7a86009ad0606325782a3ad161a61063fa96eaebbe0080b1a2d2d53e58`
  (config `sha256:ec58f91de53a805e8a57e56df8c51159d39a3b1f85bf945e4b04ff72bebfb9d0`)
- PR code overlaid in that environment at exact head
  `34f339507b7f00c74f8a157b47596dc86f8ccd43`
- Slime: `fb42ae456fac8166afb604f13b30d22bb3c75053`
- Megatron-LM: `1dcf0dafa884ad52ffb243625717a3471643e087`
- PyTorch `2.9.1+cu129`, Megatron Core `0.16.0rc0`, Ray `2.55.1`,
  SGLang `0.5.10.post1`

The platform does not expose the Kubernetes pod `imageID`; the manifest above
is the registry identity to which the freshly queried `latest` tag resolved at
test time.

### Unit tests

Focused test suite:

```bash
PYTHONPATH="$PWD:$PWD/slime:/root/Megatron-LM" \
python3 -m pytest -q \
  tests/test_mopd.py \
  tests/test_mopd_loss.py \
  tests/test_mopd_metrics.py \
  tests/test_convert_samples_multi_segment.py
```

Result: **34 passed** (rerun after installing the documented optional recipe
dependencies, also 34 passed).

Coverage includes reward-free clipped teacher/student advantages, the direct
log-probability loss without a PPO ratio, rejection of incompatible pure-MOPD
options, routed-teacher metrics, and response-token alignment for converted
multi-segment samples.

### End-to-end test

Validated the exact PR head `34f339507b7f00c74f8a157b47596dc86f8ccd43`
on one node with **8 x NVIDIA H100 80 GiB**:

- topology: TP4 / CP2 / PP1 / DP1
- 20 full-episode mixed ALFWorld and HotpotQA rollouts
- routed frozen teachers: ALFWorld step 9 and HotpotQA step 119
- `N=1`, one optimizer step per rollout, rollout/global batch size 16
  (8 ALFWorld + 8 HotpotQA prompts per rollout)
- full recipe limits: ALFWorld 30 environment/agent steps and HotpotQA 5 agent
  steps; context 49,152 and response cap 4,096
- all 20 optimizer steps completed with finite loss and gradient norm
- step 19: loss `-0.0120161800`, gradient norm `2.5494002478`
- reward over completed trajectories: 182/317 (`0.57413`), comprising
  ALFWorld 76/157 (`0.48408`) and HotpotQA 106/160 (`0.66250`)
- iteration-9 and iteration-19 checkpoints both completed and were validated
- final trained-student SGLang refresh completed 28/28 chunks
- Ray job succeeded and the launcher exited 0

The base image did not contain the optional whitebox recipe dependencies
(`textworld` and `faiss`). The passing run installed the dependencies documented
by the recipe and preflighted ALFWorld reset and Hotpot local search before
launching the unchanged MOPD configuration.

Three of 160 nominal ALFWorld trajectories (1.875%) exceeded the proxy request
size and returned HTTP 413: two in rollout 0 and one in rollout 8. They were
handled by the existing failed-placeholder path; no further 413 occurred, all
20 optimizer steps remained finite, both scheduled checkpoints completed, and
the job exited successfully. This is disclosed as a current ALFWorld harness
limitation: `ALFWORLD_HISTORY_WINDOW` is exported but is not yet applied by the
public whitebox agent. Environment reward remains monitoring-only and these
failed placeholders do not provide MOPD gradients.

This is a full training-path E2E rather than a unit-test-only smoke: dataset
sampling -> real environment/tool rollout -> route selection -> both frozen
teacher forwards -> student-old scoring -> MOPD backward/Adam update ->
checkpoint save -> trained-student weight refresh -> clean launcher exit.

## Compatibility

- No Slime source or submodule revision changes.
- Existing non-MOPD training paths are unaffected.
- The dedicated MOPD entrypoint intentionally rejects configurations that
  would mix the standalone MOPD loss with GRPO/OPD-style auxiliary objectives.

## Checklist

- [x] Focused unit tests pass (34/34)
- [x] Exact-SHA 20-step mixed-teacher 8-GPU E2E completes successfully
- [x] Checkpoint save and post-update weight refresh pass
- [x] Partial trajectory failures are quantified and disclosed
- [x] Documentation updated
