### PR TITLE
Pluggable tool-call side-effect hooks for blackbox rollouts

### DIFF
--- a/blackbox_server/adapters/claude_code.py
+++ b/blackbox_server/adapters/claude_code.py
@@ -626,6 +626,7 @@ class ClaudeCodeAdapter(BackendAdapter):
             router_api_path=binding_context.binding.router_api_path,
             bound_session_id=bound_session_id,
             bound_instance_id=bound_instance_id,
+            bound_sandbox_id=binding_context.binding.bound_sandbox_id,
             sticky_header_name=options.proxy.sticky_header_name,
             max_steps=options.proxy.max_steps,
             default_temperature=options.proxy.default_temperature,

--- a/blackbox_server/adapters/codex.py
+++ b/blackbox_server/adapters/codex.py
@@ -739,6 +739,7 @@ class CodexAdapter(BackendAdapter):
             router_api_path=binding_context.binding.router_api_path,
             bound_session_id=bound_session_id,
             bound_instance_id=bound_instance_id,
+            bound_sandbox_id=binding_context.binding.bound_sandbox_id,
             sticky_header_name=options.proxy.sticky_header_name,
             max_steps=options.proxy.max_steps,
             default_temperature=options.proxy.default_temperature,

--- a/blackbox_server/adapters/openclaw.py
+++ b/blackbox_server/adapters/openclaw.py
@@ -678,6 +678,7 @@ class OpenClawAdapter(BackendAdapter):
             router_api_path=binding_context.binding.router_api_path,
             bound_session_id=bound_session_id,
             bound_instance_id=bound_instance_id,
+            bound_sandbox_id=binding_context.binding.bound_sandbox_id,
             sticky_header_name=options.proxy.sticky_header_name,
             max_steps=options.proxy.max_steps,
             default_temperature=options.proxy.default_temperature,

--- a/blackbox_server/adapters/opencode.py
+++ b/blackbox_server/adapters/opencode.py
@@ -441,6 +441,7 @@ class OpencodeAdapter(BackendAdapter):
             router_api_path=binding_context.binding.router_api_path,
             bound_session_id=bound_session_id,
             bound_instance_id=bound_instance_id,
+            bound_sandbox_id=binding_context.binding.bound_sandbox_id,
             sticky_header_name=options.proxy.sticky_header_name,
             max_steps=options.proxy.max_steps,
             default_temperature=options.proxy.default_temperature,

--- a/blackbox_server/core/hashing.py
+++ b/blackbox_server/core/hashing.py
@@ -55,6 +55,7 @@ def binding_request_fingerprint(request: RegisterRequest, router_base_url: str) 
         "router_base_url": router_base_url,
         "bound_session_id": request.bound_session_id,
         "bound_instance_id": request.bound_instance_id,
+        "bound_sandbox_id": request.bound_sandbox_id,
         "system_prompt_file": system_prompt_file,
         "backend_options": request.backend_options,
         "server_config": server_config,

--- a/blackbox_server/core/models.py
+++ b/blackbox_server/core/models.py
@@ -118,6 +118,7 @@ class BindingInfo(BaseModel):
     router_api_path: str
     bound_session_id: str
     bound_instance_id: str
+    bound_sandbox_id: str | None = None
     system_prompt: RuntimeSystemPrompt | None = None
     runtime_dir: str
     registered_at: datetime
@@ -170,6 +171,7 @@ class RegisterRequest(BaseModel):
     router_api_path: str = "/v1"
     bound_session_id: str | None = None
     bound_instance_id: str | None = None
+    bound_sandbox_id: str | None = None
     system_prompt_file: str | None = None
     backend_options: dict[str, Any] = Field(default_factory=dict)
     server_config: ServerConfigOverride | None = None

--- a/blackbox_server/core/server.py
+++ b/blackbox_server/core/server.py
@@ -1311,6 +1311,7 @@ class BlackboxServer:
             router_api_path=router_api_path,
             bound_session_id=request.bound_session_id or "",
             bound_instance_id=request.bound_instance_id or "",
+            bound_sandbox_id=request.bound_sandbox_id or None,
             system_prompt=system_prompt,
             runtime_dir=runtime_dir,
             registered_at=utcnow(),

--- a/blackbox_server/proxy/rollout_llm_proxy.py
+++ b/blackbox_server/proxy/rollout_llm_proxy.py
@@ -59,6 +59,7 @@ class RolloutLLMProxy:
         bound_session_id: str,
         bound_instance_id: str,
         sticky_header_name: str,
+        bound_sandbox_id: str | None = None,
         max_steps: int | None = DEFAULT_PROXY_MAX_STEPS,
         default_temperature: float | None = None,
         debug_log_dir: str | Path | None = None,
@@ -75,6 +76,7 @@ class RolloutLLMProxy:
         self.router_api_path = router_api_path.rstrip("/") or "/"
         self.bound_session_id = bound_session_id
         self.bound_instance_id = bound_instance_id
+        self.bound_sandbox_id = bound_sandbox_id
         self.sticky_header_name = sticky_header_name
         self.max_steps = max_steps
         self.default_temperature = default_temperature
@@ -683,6 +685,7 @@ class RolloutLLMProxy:
                     "x-turn-id",
                     "x-dressage-partial-rollout",
                     "x-dressage-expected-version",
+                    "x-dressage-sandbox-id",
                 }
             )
         if is_anthropic:
@@ -710,6 +713,8 @@ class RolloutLLMProxy:
             self._set_header(headers, "X-Instance-Id", self.bound_instance_id)
             if turn_id:
                 self._set_header(headers, "X-Turn-Id", turn_id)
+            if self.bound_sandbox_id:
+                self._set_header(headers, "X-Dressage-Sandbox-Id", self.bound_sandbox_id)
             self._set_header(headers, "X-Dressage-Partial-Rollout", "1")
             if self._current_version is not None:
                 self._set_header(headers, "X-Dressage-Expected-Version", str(self._current_version))

--- a/docs/tool_call_hooks_proposal.md
+++ b/docs/tool_call_hooks_proposal.md
@@ -1,0 +1,148 @@
+# Proposal: Pluggable Tool-Call Side-Effect Hooks for Blackbox Rollouts
+
+## Motivation
+
+During blackbox rollouts (opencode / claude_code / codex agents running inside
+sandboxes), several workflows need to run side effects at tool-execution
+boundaries:
+
+- **Sandbox snapshotting** — capture sandbox state after each tool round for
+  post-hoc analysis, reward computation, or reproducible debugging.
+- **Network policy toggling** — keep sandboxes network-isolated by default and
+  restore egress only while tools that need connectivity are about to run.
+- **Per-step observability** — record which tools ran, when, and how long the
+  gaps between tool rounds are, correlated with the training trajectory.
+
+The Dressage proxy is the natural place to observe these boundaries: it already
+normalizes all agent protocols (Anthropic Messages, OpenAI Responses, OpenAI
+chat) into a single OpenAI chat format, so `role=tool` messages and parsed
+`tool_calls` are agent-agnostic. However, the proxy never sees *actual* tool
+execution — it only sees the request stream. This proposal adds a hook layer
+at the two observable step boundaries, without coupling the proxy to any
+specific sandbox provider.
+
+## Design
+
+### Hook points (derived from one `/chat/completions` request)
+
+| Hook | Fires when | Semantics |
+|---|---|---|
+| `after_tool_call` | The normalized request messages end with `role=tool` | The previous step's tools **already executed** in the sandbox (e.g. take a snapshot) |
+| `before_tool_call` | The response contains non-empty parsed `tool_calls`, **before** the response is returned | Tools are **about to execute** once the agent receives the response (e.g. restore networking). Runs synchronously; the agent is guaranteed to see a prepared sandbox |
+
+Both are *step-boundary* level side effects, not per-tool interception.
+
+### Interface (`dressage/proxy/tool_call_hooks.py`)
+
+```python
+@dataclass(frozen=True)
+class ToolCallContext:
+    instance_id: str | None        # training instance / rollout worker
+    session_id: str                # == trajectory_id
+    turn_id: str | None            # one agent call
+    step_index: int                # one LLM request
+    sandbox_id: str                # provider-native id (e.g. e2b), for
+                                   # AsyncSandbox.connect(sandbox_id)
+    tool_calls: list[dict] | None  # non-empty only for before-stage
+    idempotency_key: str | None    # "session:turn:step:stage"
+    stage_metadata: dict[str, Any] # hook results land in trajectory metadata
+
+
+class ToolCallHook(abc.ABC):
+    name: ClassVar[str]            # registry key
+    required: ClassVar[bool]       # True: failure aborts the request (502)
+    order: ClassVar[int] = 100     # before: ascending; after: descending
+
+    def applies_to(self, ctx) -> bool: ...
+    async def before_tool_call(self, ctx) -> None: ...
+    async def after_tool_call(self, ctx) -> None: ...
+```
+
+### Key decisions
+
+1. **Side-effect only** — hooks return nothing and cannot mutate requests or
+   responses. No interceptor semantics.
+2. **Pluggable, not built-in** — with no hooks configured the chain is `None`
+   and dispatch is a zero-cost no-op.
+3. **Run-level configuration** — one chain for the whole proxy lifetime; no
+   per-task differentiation (keeps rollout determinism).
+4. **Hooks own their provider client** — the proxy only dispatches and hands
+   over context. Hooks reconnect to sandboxes themselves via the native
+   `sandbox_id`, so the proxy stays provider-agnostic.
+5. **Failure semantics mirror `blackbox_execute_cmds`** — `required=True`
+   hook failures (or `before_timeout` expiry) abort the request with HTTP 502
+   so the agent never executes tools against an unprepared sandbox; optional
+   failures are logged and recorded into `stage_metadata`, and the chain
+   continues.
+6. **Idempotency** — each dispatch claims a `session:turn:step:stage` key;
+   duplicate dispatches (HTTP retries, partial-rollout replays) are skipped.
+   Keys are purged on session finalize/discard and expire after a TTL
+   (default 1h) as a leak backstop.
+
+### `sandbox_id` plumbing (required for e2b)
+
+The provider-native sandbox id must travel from the rollout worker to the
+proxy. This PR threads it through the existing register/binding path:
+
+```
+paddock.init() → lease.sandbox_id
+  → register payload `bound_sandbox_id`          (dressage/paddock/blackbox/client.py)
+  → BindingInfo.bound_sandbox_id                 (blackbox_server/core/models.py)
+  → RolloutLLMProxy(bound_sandbox_id=...)        (all four adapters' _start_proxy)
+  → header X-Dressage-Sandbox-Id per LLM request (blackbox_server/proxy/rollout_llm_proxy.py)
+  → proxy parses header → ctx.sandbox_id         (dressage/proxy/server.py)
+```
+
+The header is reserved (client-supplied values are stripped), so in-sandbox
+agents cannot spoof it. `bound_sandbox_id` also participates in the register
+fingerprint so a changed sandbox id correctly triggers a full rebind instead
+of an idempotent replay of a stale binding.
+
+### Configuration
+
+```bash
+dressage-proxy --tokenizer-path ... \
+    --tool-call-hooks e2b_snapshot restore_network \
+    --tool-call-hook-before-timeout 5.0
+```
+
+Each entry may be a registered hook name, `module:ClassName`,
+`/path/file.py:ClassName`, or a bare `/path/file.py` when the file registers
+exactly one hook. Loading happens once at startup; bad references fail fast.
+
+Hook results written to `ctx.stage_metadata` are persisted into finalized
+trajectory segments under `extra_info["tool_call_hooks"]`, giving full
+visibility into what side effects ran for every training sample.
+
+## Files changed
+
+| Layer | File | Change |
+|---|---|---|
+| new | `dressage/proxy/tool_call_hooks.py` | Context, abstract hook, chain dispatcher, registry, loader, idempotency keys |
+| proxy | `dressage/proxy/server.py` | Parse `X-Dressage-Sandbox-Id`; dispatch after (request tail `role=tool`) and before (parsed `tool_calls`, pre-response); `create_app` params; CLI flags; metadata into StepRecord → finalize |
+| proxy | `dressage/proxy/session_manager.py` | `StepRecord.tool_call_hook_metadata` field |
+| in-sandbox proxy | `blackbox_server/proxy/rollout_llm_proxy.py` | `bound_sandbox_id` ctor param; attach `X-Dressage-Sandbox-Id` header; reserve header |
+| binding | `blackbox_server/core/models.py` | `RegisterRequest` / `BindingInfo` gain `bound_sandbox_id` |
+| binding | `blackbox_server/core/server.py` | Thread `bound_sandbox_id` into new bindings |
+| binding | `blackbox_server/core/hashing.py` | Include `bound_sandbox_id` in the register fingerprint |
+| adapters | `opencode.py` / `claude_code.py` / `codex.py` / `openclaw.py` | Pass `bound_sandbox_id` to `RolloutLLMProxy` |
+| dressage client | `dressage/paddock/blackbox/client.py`, `paddock.py` | Send `state.sandbox_id` as `bound_sandbox_id` on register |
+| example | `examples/tool_call_hooks_example.py` | Four documented example hooks (snapshot, network restore, selective watch, timing) |
+| tests | `tests/test_tool_call_hooks.py` | 22 tests: chain semantics, registry/loader, pipeline integration, header forwarding, register plumbing, fingerprint regression |
+
+## Out of scope (explicitly)
+
+- Finalize-time hook fallbacks.
+- Per-task hook configuration.
+- Response-rewriting interceptors.
+- Dynamic tool disabling via config mutation (blocked on opencode runtime
+  permission changes; static deny stays with `backend_options` permissions).
+
+## Example
+
+See `examples/tool_call_hooks_example.py` for four ready-to-use hooks:
+
+```bash
+dressage-proxy --tokenizer-path ... \
+    --tool-call-hooks examples/tool_call_hooks_example.py:e2b_snapshot
+```

--- a/dressage/paddock/blackbox/client.py
+++ b/dressage/paddock/blackbox/client.py
@@ -70,6 +70,7 @@ class BlackboxServerClient:
         server_config: dict[str, Any],
         router_api_path: str = "/v1",
         system_prompt_file: str | None = None,
+        sandbox_id: str | None = None,
     ) -> dict[str, Any]:
         payload = {
             "blackbox_type": blackbox_type,
@@ -80,6 +81,8 @@ class BlackboxServerClient:
             "backend_options": backend_options,
             "server_config": server_config,
         }
+        if sandbox_id:
+            payload["bound_sandbox_id"] = sandbox_id
         if system_prompt_file is not None:
             payload["system_prompt_file"] = system_prompt_file
         response = await self._post_agent_with_retry(

--- a/dressage/paddock/blackbox/paddock.py
+++ b/dressage/paddock/blackbox/paddock.py
@@ -178,6 +178,7 @@ class BlackboxAgentPaddock(BlackboxPaddock):
             server_config=_server_config_for_provider(self._provider.name, blackbox_type),
             router_api_path=router_api_path,
             system_prompt_file=system_prompt_file,
+            sandbox_id=state.sandbox_id,
         )
 
     async def call_agent(

--- a/dressage/proxy/server.py
+++ b/dressage/proxy/server.py
@@ -14,7 +14,7 @@ import uuid
 from contextlib import asynccontextmanager
 
 import httpx
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
@@ -55,6 +55,14 @@ from .reasoning_parser import ProxyReasoningParser, canonicalize_reasoning_conte
 from .routed_experts import canonicalize_routed_experts
 from .session_manager import Route, Session, SessionFinalizedError, SessionManager, StepRecord
 from .sglang_client import SGLangRouterClient
+from .tool_call_hooks import (
+    ToolCallContext,
+    ToolCallHookChain,
+    ToolCallHookError,
+    build_tool_call_idempotency_key,
+    build_tool_call_hook_chain,
+    load_tool_call_hooks,
+)
 from .tool_call_parser import (
     ModelToolCallParserRegistry,
     ProxyToolCallParser,
@@ -131,36 +139,51 @@ def _consume_task_exception(task: asyncio.Task[Any]) -> None:
         task.exception()
 
 
-def _positive_int(value: str) -> int:
-    try:
-        parsed = int(value)
-    except ValueError as exc:
-        raise argparse.ArgumentTypeError("must be an integer") from exc
-    if parsed <= 0:
-        raise argparse.ArgumentTypeError("must be greater than 0")
-    return parsed
+def _bounded_number(
+    *,
+    kind: type[int] | type[float],
+    minimum: float,
+    exclusive: bool,
+) -> Callable[[str], int | float]:
+    """Build an argparse ``type=`` parser for a numeric CLI argument.
+
+    The four call sites below previously repeated the same parse / range /
+    error-message boilerplate; this factory keeps their behavior (and the
+    exact error strings) identical while collapsing them into one place.
+    """
+
+    kind_name = "an integer" if kind is int else "a number"
+    if exclusive:
+        bound = "greater than"
+        threshold = minimum
+    else:
+        bound = "greater than or equal to"
+        threshold = minimum
+    finite = kind is float
+    range_message = (
+        f"must be a finite number {bound} {threshold:g}"
+        if finite
+        else f"must be {bound} {threshold:g}"
+    )
+
+    def parse(value: str) -> int | float:
+        try:
+            parsed = kind(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(f"must be {kind_name}") from exc
+        if finite and not math.isfinite(parsed):
+            raise argparse.ArgumentTypeError(range_message)
+        if parsed < threshold or (exclusive and parsed == threshold):
+            raise argparse.ArgumentTypeError(range_message)
+        return parsed
+
+    return parse
 
 
-def _non_negative_int(value: str) -> int:
-    try:
-        parsed = int(value)
-    except ValueError as exc:
-        raise argparse.ArgumentTypeError("must be an integer") from exc
-    if parsed < 0:
-        raise argparse.ArgumentTypeError("must be greater than or equal to 0")
-    return parsed
-
-
-def _non_negative_finite_float(value: str) -> float:
-    try:
-        parsed = float(value)
-    except ValueError as exc:
-        raise argparse.ArgumentTypeError("must be a number") from exc
-    if not math.isfinite(parsed) or parsed < 0:
-        raise argparse.ArgumentTypeError(
-            "must be a finite number greater than or equal to 0"
-        )
-    return parsed
+_positive_int = _bounded_number(kind=int, minimum=0, exclusive=True)
+_non_negative_int = _bounded_number(kind=int, minimum=0, exclusive=False)
+_non_negative_finite_float = _bounded_number(kind=float, minimum=0, exclusive=False)
+_positive_float = _bounded_number(kind=float, minimum=0, exclusive=True)
 
 
 def _real_token_version(value: Any) -> str | None:
@@ -482,6 +505,15 @@ def _runtime_ids_from_request(
     return session_id, instance_id, turn_id
 
 
+def _sandbox_id_from_request(request: Request, body: dict[str, Any]) -> str | None:
+    """Provider-native sandbox id forwarded by the in-sandbox rollout proxy."""
+
+    return (
+        request.headers.get("X-Dressage-Sandbox-Id")
+        or body.get("sandbox_id")
+    )
+
+
 def _assistant_message(
     content: str | None,
     tool_calls: list[dict] | None,
@@ -652,6 +684,9 @@ def create_app(
     transfer_params: tuple[str, ...] | list[str] | str | None = None,
     transfer_queue_store_id: str | None = None,
     transfer_queue_runtime: TransferQueueRuntime | None = None,
+    tool_call_hooks: str | tuple[str, ...] | list[str] | None = None,
+    tool_call_hook_chain: ToolCallHookChain | None = None,
+    tool_call_hook_before_timeout: float | None = None,
 ) -> FastAPI:
     """Create the Dressage proxy FastAPI app."""
 
@@ -724,6 +759,17 @@ def create_app(
             "local reasoning parser only supports qwen3/qwen3_5, "
             f"got {model_reasoning_type!r}"
         )
+    if tool_call_hook_chain is not None and tool_call_hooks:
+        raise ValueError(
+            "tool_call_hook_chain and tool_call_hooks are mutually exclusive"
+        )
+    if (
+        tool_call_hook_before_timeout is not None
+        and tool_call_hook_before_timeout <= 0
+    ):
+        raise ValueError(
+            "tool_call_hook_before_timeout must be greater than 0 when provided"
+        )
 
     build_defaults = token_build_defaults(
         token_build_mode=token_build_mode,
@@ -756,6 +802,10 @@ def create_app(
 
     trajectory_store = trajectory_store or TrajectoryStore()
     session_manager = session_manager or SessionManager()
+    tool_call_hook_chain = tool_call_hook_chain or build_tool_call_hook_chain(
+        load_tool_call_hooks(tool_call_hooks),
+        before_timeout=tool_call_hook_before_timeout,
+    )
     sglang_client = sglang_client or SGLangRouterClient(
         sglang_router_url,
         return_routed_experts=use_rollout_routing_replay,
@@ -995,6 +1045,117 @@ def create_app(
                 )
             raise
 
+    async def _dispatch_tool_call_hooks(
+        *,
+        stage: str,
+        session_id: str,
+        sandbox_id: str | None,
+        instance_id: str | None,
+        turn_id: str | None,
+        step_index: int,
+        metadata: dict[str, Any],
+        tool_calls: list[dict] | None = None,
+    ) -> None:
+        """Dispatch one tool-call hook stage; no-op without a chain.
+
+        Required-hook failures surface as HTTP 502 so the blackbox agent
+        aborts the rollout instead of executing tools against an
+        unprepared sandbox.
+        """
+
+        if tool_call_hook_chain is None:
+            return
+        if not sandbox_id:
+            logger.warning(
+                "tool-call hooks are configured but the request carries no "
+                "sandbox id; skipping %s dispatch: session_id=%s",
+                stage,
+                session_id,
+            )
+            return
+        ctx = ToolCallContext(
+            instance_id=instance_id,
+            session_id=session_id,
+            turn_id=turn_id,
+            step_index=step_index,
+            sandbox_id=sandbox_id,
+            tool_calls=tool_calls,
+            idempotency_key=build_tool_call_idempotency_key(
+                session_id=session_id,
+                turn_id=turn_id,
+                step_index=step_index,
+                stage=stage,
+            ),
+            stage_metadata=metadata,
+        )
+        try:
+            if stage == "before":
+                await tool_call_hook_chain.run_before(ctx)
+            else:
+                await tool_call_hook_chain.run_after(ctx)
+        except ToolCallHookError as exc:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "tool_call_hook_failed",
+                    "stage": stage,
+                    "message": str(exc),
+                    "session_id": session_id,
+                    "instance_id": instance_id,
+                },
+            ) from exc
+
+    async def _dispatch_after_tool_call_hooks(
+        *,
+        session_id: str,
+        sandbox_id: str | None,
+        instance_id: str | None,
+        turn_id: str | None,
+        step_index: int,
+        normalized_request_messages: list[dict],
+        metadata: dict[str, Any],
+    ) -> None:
+        """after_tool_call: the request tail is a tool result message."""
+
+        if tool_call_hook_chain is None:
+            return
+        if not normalized_request_messages:
+            return
+        if normalized_request_messages[-1].get("role") != "tool":
+            return
+        await _dispatch_tool_call_hooks(
+            stage="after",
+            session_id=session_id,
+            sandbox_id=sandbox_id,
+            instance_id=instance_id,
+            turn_id=turn_id,
+            step_index=step_index,
+            metadata=metadata,
+        )
+
+    async def _dispatch_before_tool_call_hooks(
+        *,
+        session_id: str,
+        sandbox_id: str | None,
+        instance_id: str | None,
+        turn_id: str | None,
+        step_index: int,
+        tool_calls: list[dict],
+        metadata: dict[str, Any],
+    ) -> None:
+        """before_tool_call: parsed tool_calls are about to execute."""
+
+        await _dispatch_tool_call_hooks(
+            stage="before",
+            session_id=session_id,
+            sandbox_id=sandbox_id,
+            instance_id=instance_id,
+            turn_id=turn_id,
+            step_index=step_index,
+            metadata=metadata,
+            tool_calls=tool_calls,
+        )
+
     def _step_routed_experts_row_count(step: StepRecord) -> int:
         if token_build_mode == "snapshot":
             return max(0, len(step.all_token_ids) - 1)
@@ -1186,6 +1347,8 @@ def create_app(
             extra_info["snapshot_logprobs_invalid"] = True
         if mask_nonlast_version_tokens:
             extra_info["mask_nonlast_version_tokens"] = True
+        if step.tool_call_hook_metadata:
+            extra_info["tool_call_hooks"] = dict(step.tool_call_hook_metadata)
 
         record = {
             "uid": str(uuid.uuid4()),
@@ -1295,6 +1458,12 @@ def create_app(
             extra_info["tito_incremental_tokenization_failed"] = True
         if mask_nonlast_version_tokens:
             extra_info["mask_nonlast_version_tokens"] = True
+        hook_metadata: dict[str, Any] = {}
+        for step in steps:
+            for key, value in step.tool_call_hook_metadata.items():
+                hook_metadata.setdefault(key, []).append(value)
+        if hook_metadata:
+            extra_info["tool_call_hooks"] = hook_metadata
 
         response_logprobs = build_concatenated_logprobs(
             step_logprobs,
@@ -1661,6 +1830,7 @@ def create_app(
         include_usage = stream_options.get("include_usage", True) is not False
 
         session_id, instance_id, turn_id = _runtime_ids_from_request(request, body)
+        sandbox_id = _sandbox_id_from_request(request, body)
         try:
             session, _ = session_manager.get_or_create_session(
                 session_id, messages, instance_id=instance_id
@@ -1691,6 +1861,16 @@ def create_app(
                 partial_rollout=partial_rollout,
             )
             normalized_request_messages = mask_builder.normalize_template_messages(messages)
+            tool_call_hook_metadata: dict[str, Any] = {}
+            await _dispatch_after_tool_call_hooks(
+                session_id=session_id,
+                sandbox_id=sandbox_id,
+                instance_id=instance_id,
+                turn_id=effective_turn_id,
+                step_index=len(session.steps),
+                normalized_request_messages=normalized_request_messages,
+                metadata=tool_call_hook_metadata,
+            )
             current_tools_hash = _tools_hash(
                 tools,
                 none_equals_empty=none_equals_empty_tools,
@@ -2014,6 +2194,15 @@ def create_app(
                 content = _strip_public_stop_markers(content)
                 if tool_calls:
                     finish_reason = "tool_calls"
+                    await _dispatch_before_tool_call_hooks(
+                        session_id=session_id,
+                        sandbox_id=sandbox_id,
+                        instance_id=instance_id,
+                        turn_id=effective_turn_id,
+                        step_index=len(session.steps),
+                        tool_calls=tool_calls,
+                        metadata=tool_call_hook_metadata,
+                    )
 
             full_messages = messages + [
                 _assistant_message(
@@ -2155,6 +2344,7 @@ def create_app(
                 finish_reason=finish_reason,
                 request_version=str(request_version),
                 response_version=str(response_version),
+                tool_call_hook_metadata=tool_call_hook_metadata,
             )
 
             if output_overflow:
@@ -2309,6 +2499,11 @@ def create_app(
         _check_auth(request)
         body = await request.json()
         session_id = str(body["session_id"])
+        purged_hook_keys = (
+            tool_call_hook_chain.purge_session(session_id)
+            if tool_call_hook_chain is not None
+            else 0
+        )
 
         if not enable_transfer_queue:
             session_removed = session_manager.discard_session(session_id)
@@ -2318,6 +2513,7 @@ def create_app(
                 "session_id": session_id,
                 "session_removed": session_removed,
                 "segments_removed": len(removed_segments),
+                "tool_call_hook_keys_purged": purged_hook_keys,
             }
 
         async def _discard_state(active_session: Session | None) -> dict[str, Any]:
@@ -2356,6 +2552,7 @@ def create_app(
                 "session_id": session_id,
                 "session_removed": session_removed,
                 "segments_removed": len(removed_segments),
+                "tool_call_hook_keys_purged": purged_hook_keys,
             }
 
         active_session = session_manager.get_session(session_id)
@@ -2500,6 +2697,11 @@ def create_app(
             )
             if finalized is not session:  # defensive; request_lock owns finalize
                 raise RuntimeError("session changed during atomic finalization")
+
+        if tool_call_hook_chain is not None:
+            purged = tool_call_hook_chain.purge_session(session_id)
+            if purged:
+                finalization_result["tool_call_hook_keys_purged"] = purged
 
         return finalization_result
 
@@ -2830,6 +3032,22 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Trajectory fields to offload: logprobs routed_experts.",
     )
+    parser.add_argument(
+        "--tool-call-hooks",
+        nargs="+",
+        default=None,
+        help=(
+            "Pluggable tool-call side-effect hooks (run-level). Each entry is "
+            "a registered hook name or 'module:ClassName' / file path that "
+            "self-registers on import."
+        ),
+    )
+    parser.add_argument(
+        "--tool-call-hook-before-timeout",
+        type=_positive_float,
+        default=None,
+        help="Per-hook timeout in seconds for before_tool_call dispatches.",
+    )
     args = parser.parse_args()
     if not args.enable_transfer_queue:
         args.transfer_queue_config = None
@@ -2896,6 +3114,8 @@ def main() -> None:
         transfer_queue_config=args.transfer_queue_config,
         transfer_queue_retention_seconds=args.transfer_queue_retention_seconds,
         transfer_params=args.transfer_params,
+        tool_call_hooks=args.tool_call_hooks,
+        tool_call_hook_before_timeout=args.tool_call_hook_before_timeout,
     )
     uvicorn.run(app, host=args.host, port=args.port)
 

--- a/dressage/proxy/session_manager.py
+++ b/dressage/proxy/session_manager.py
@@ -143,6 +143,7 @@ class StepRecord:
     finish_reason: str = "stop"
     request_version: str | None = None
     response_version: str | None = None
+    tool_call_hook_metadata: dict[str, Any] = field(default_factory=dict)
     timestamp: float = field(default_factory=time.time)
 
 
@@ -459,6 +460,7 @@ class SessionManager:
         finish_reason: str = "stop",
         request_version: str | None = None,
         response_version: str | None = None,
+        tool_call_hook_metadata: dict[str, Any] | None = None,
     ) -> StepRecord | None:
         with self._lock:
             session = self._sessions.get(session_id)
@@ -545,6 +547,7 @@ class SessionManager:
                 finish_reason=finish_reason,
                 request_version=request_version,
                 response_version=response_version,
+                tool_call_hook_metadata=dict(tool_call_hook_metadata or {}),
             )
             session.steps.append(step)
             session.steps_by_id[step.step_id] = step

--- a/dressage/proxy/tool_call_hooks.py
+++ b/dressage/proxy/tool_call_hooks.py
@@ -1,0 +1,496 @@
+"""Pluggable side-effect hooks around blackbox tool-call boundaries.
+
+The Dressage proxy observes the *request stream* of blackbox CLI agents
+(opencode / claude_code / codex ...).  Two step-boundary hook points are
+derived from one ``/chat/completions`` request:
+
+- ``after_tool_call``: the normalized request messages end with a
+  ``role=tool`` message, which means the previous step's tools already
+  executed inside the sandbox (e.g. take a sandbox snapshot).
+- ``before_tool_call``: the model response for this request contains
+  non-empty ``tool_calls``, which means tools are about to execute once
+  the response is returned (e.g. restore sandbox networking).
+
+Hooks are side-effect only: no return values, no request/response
+mutation.  They are pluggable and not built in; when nothing is
+configured the chain is a no-op.  Configuration is run-level (one chain
+for the whole proxy lifetime).
+
+Each hook carries its own provider client and connects to the sandbox
+itself using the native ``sandbox_id`` (for e2b:
+``AsyncSandbox.connect(sandbox_id)``); the proxy only dispatches and
+hands over context.
+"""
+
+from __future__ import annotations
+
+import abc
+import asyncio
+import hashlib
+import time
+from dataclasses import dataclass, field
+import importlib
+import importlib.util
+import inspect
+import logging
+from pathlib import Path
+import sys
+from typing import Any, ClassVar, Iterable
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_KEY_TTL_SECONDS = 3600.0
+_PRUNE_INTERVAL_SECONDS = 300.0
+_PRUNE_MAX_KEYS_PER_ROUND = 10_000
+
+__all__ = [
+    "ToolCallContext",
+    "ToolCallHook",
+    "ToolCallHookChain",
+    "ToolCallHookError",
+    "register_tool_call_hook",
+    "registered_tool_call_hooks",
+    "reset_tool_call_hook_registry",
+    "load_tool_call_hooks",
+    "build_tool_call_hook_chain",
+    "build_tool_call_idempotency_key",
+]
+
+
+@dataclass(frozen=True)
+class ToolCallContext:
+    """Context handed to every hook dispatch.
+
+    Fields follow the rollout hierarchy: ``instance_id`` (training
+    instance / rollout worker) > ``session_id`` (== trajectory id) >
+    ``turn_id`` (one agent call) > ``step_index`` (one LLM request).
+    ``sandbox_id`` is the provider-native sandbox id (e.g. the e2b
+    sandbox id) used by hooks to reconnect to the sandbox from the
+    proxy side.
+    """
+
+    instance_id: str | None
+    session_id: str
+    turn_id: str | None
+    step_index: int
+    sandbox_id: str
+    tool_calls: list[dict] | None = None
+    idempotency_key: str | None = None
+    stage_metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class ToolCallHookError(RuntimeError):
+    """Raised when a required hook fails or times out."""
+
+
+class ToolCallHook(abc.ABC):
+    """Base class for pluggable tool-call side-effect hooks."""
+
+    name: ClassVar[str] = ""
+    required: ClassVar[bool] = False
+    order: ClassVar[int] = 100
+
+    def applies_to(self, ctx: ToolCallContext) -> bool:  # noqa: ARG002
+        return True
+
+    async def before_tool_call(self, ctx: ToolCallContext) -> None:  # noqa: ARG002
+        return None
+
+    async def after_tool_call(self, ctx: ToolCallContext) -> None:  # noqa: ARG002
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Registry (decorator / subclass registration)
+# ---------------------------------------------------------------------------
+
+_HOOK_REGISTRY: dict[str, type[ToolCallHook]] = {}
+
+
+def register_tool_call_hook(hook_cls: type[ToolCallHook]) -> type[ToolCallHook]:
+    """Register a hook class; usable directly or as a ``@`` decorator."""
+
+    if not (inspect.isclass(hook_cls) and issubclass(hook_cls, ToolCallHook)):
+        raise TypeError("register_tool_call_hook expects a ToolCallHook subclass")
+    name = getattr(hook_cls, "name", "")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(f"{hook_cls.__name__} must define a non-empty 'name'")
+    key = name.strip()
+    existing = _HOOK_REGISTRY.get(key)
+    if existing is not None and existing is not hook_cls:
+        # The same physical file imported through two references (e.g.
+        # "path.py:Hook" and "module.path:Hook") produces two distinct
+        # class objects; treat identical qualnames as the same hook.
+        if existing.__qualname__ != hook_cls.__qualname__:
+            raise ValueError(
+                f"tool-call hook name {key!r} is already registered by "
+                f"{existing.__module__}.{existing.__qualname__}"
+            )
+        return hook_cls
+    _HOOK_REGISTRY[key] = hook_cls
+    return hook_cls
+
+
+def _register_subclasses(module: Any) -> None:
+    for attribute in vars(module).values():
+        if (
+            inspect.isclass(attribute)
+            and issubclass(attribute, ToolCallHook)
+            and attribute is not ToolCallHook
+            and getattr(attribute, "name", "")
+            and attribute.__module__ == module.__name__
+        ):
+            register_tool_call_hook(attribute)
+
+
+def registered_tool_call_hooks() -> dict[str, type[ToolCallHook]]:
+    return dict(_HOOK_REGISTRY)
+
+
+def reset_tool_call_hook_registry() -> None:
+    _HOOK_REGISTRY.clear()
+
+
+# ---------------------------------------------------------------------------
+# Loading (run-level, one-shot)
+# ---------------------------------------------------------------------------
+
+
+def load_tool_call_hooks(spec: str | Iterable[str] | None) -> list[ToolCallHook]:
+    """Load hooks for one run.
+
+    ``spec`` is a list of hook names (or a comma/space separated string).
+    Each entry is resolved against the registry.  Entries containing ``:``
+    or a path separator are import references processed first so their
+    module-level registration side effects run:
+
+    - ``module.path:ClassName``
+    - ``/path/to/file.py:ClassName``
+    - ``/path/to/file.py`` (allowed when the file registers exactly one hook)
+    """
+
+    if spec is None:
+        return []
+    if isinstance(spec, str):
+        names = [item for item in spec.replace(",", " ").split() if item]
+    else:
+        names: list[str] = []
+        for value in spec:
+            names.extend(item for item in str(value).split() if item)
+
+    hooks: list[ToolCallHook] = []
+    for raw_name in names:
+        name = raw_name.strip()
+        if not name:
+            continue
+        if ":" in name or "/" in name or "\\" in name:
+            hooks.append(_load_hook_from_reference(name))
+            continue
+        hook_cls = _HOOK_REGISTRY.get(name)
+        if hook_cls is None:
+            raise ValueError(
+                f"unknown tool-call hook {name!r}; registered hooks: "
+                + (", ".join(sorted(_HOOK_REGISTRY)) or "<none>")
+            )
+        hooks.append(hook_cls())
+    return hooks
+
+
+def _load_hook_from_reference(reference: str) -> ToolCallHook:
+    if ":" in reference:
+        module_part, _, class_name = reference.rpartition(":")
+    else:
+        module_part, class_name = reference, None
+    module = _import_hook_module(module_part, reference=reference)
+    if class_name:
+        hook_cls = vars(module).get(class_name)
+        if not (inspect.isclass(hook_cls) and issubclass(hook_cls, ToolCallHook)):
+            raise ValueError(
+                f"{reference!r} does not reference a ToolCallHook subclass"
+            )
+        return hook_cls()
+    registered = [
+        hook_cls
+        for hook_cls in _HOOK_REGISTRY.values()
+        if hook_cls.__module__ == module.__name__
+    ]
+    if len(registered) == 1:
+        return registered[0]()
+    raise ValueError(
+        f"{reference!r} registers {len(registered)} hooks; "
+        "qualify the entry as 'path:ClassName'"
+    )
+
+
+def _import_hook_module(module_part: str, *, reference: str) -> Any:
+    looks_like_path = (
+        "/" in module_part
+        or "\\" in module_part
+        or module_part.endswith(".py")
+    )
+    if not looks_like_path:
+        module = importlib.import_module(module_part)
+        _register_subclasses(module)
+        return module
+
+    path = Path(module_part)
+    if not path.is_file():
+        raise ValueError(f"tool-call hook file not found: {reference!r}")
+    # Distinct files sharing a stem must not collide in sys.modules.
+    path_token = hashlib.sha1(str(path.resolve()).encode("utf-8")).hexdigest()[:8]
+    module_name = f"dressage_tool_call_hooks.{path.stem}_{path_token}"
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:
+            raise ValueError(f"cannot import tool-call hook file: {reference!r}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    _register_subclasses(module)
+    return module
+
+
+def build_tool_call_hook_chain(
+    hooks: Iterable[ToolCallHook] | None,
+    *,
+    before_timeout: float | None = None,
+    key_ttl_seconds: float | None = DEFAULT_KEY_TTL_SECONDS,
+) -> ToolCallHookChain | None:
+    """Build a chain from hooks, or ``None`` when no hooks are configured.
+
+    ``key_ttl_seconds`` bounds how long idempotency keys are remembered
+    (pass ``None`` to never expire).  Keys only need to survive
+    near-term retries and partial-rollout replays.
+    """
+
+    hook_list = list(hooks or [])
+    if not hook_list:
+        return None
+    return ToolCallHookChain(
+        hook_list,
+        before_timeout=before_timeout,
+        key_ttl_seconds=key_ttl_seconds,
+    )
+
+
+def build_tool_call_idempotency_key(
+    *,
+    session_id: str,
+    turn_id: str | None,
+    step_index: int,
+    stage: str,
+) -> str:
+    """Stable key (e.g. ``session:turn:step``) for duplicate suppression."""
+
+    return f"{session_id}:{turn_id or '-'}:{step_index}:{stage}"
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+class ToolCallHookChain:
+    """Ordered dispatcher over :class:`ToolCallHook` implementations.
+
+    ``before`` hooks run in ascending ``order``; ``after`` hooks run in
+    descending ``order``.  Failures follow the execute-cmd semantics: a
+    ``required`` hook failure (or timeout) aborts the request; optional
+    failures are logged and the chain continues.
+    """
+
+    def __init__(
+        self,
+        hooks: Iterable[ToolCallHook],
+        *,
+        before_timeout: float | None = None,
+        key_ttl_seconds: float | None = DEFAULT_KEY_TTL_SECONDS,
+    ) -> None:
+        self._hooks = sorted(hooks, key=lambda hook: hook.order)
+        self._before_timeout = before_timeout
+        self._key_ttl_seconds = key_ttl_seconds
+        # session_id -> {idempotency_key: claimed_at (monotonic)}
+        self._seen_keys: dict[str, dict[str, float]] = {}
+        self._last_prune = time.monotonic()
+
+    @property
+    def hooks(self) -> list[ToolCallHook]:
+        return list(self._hooks)
+
+    @property
+    def before_timeout(self) -> float | None:
+        return self._before_timeout
+
+    @property
+    def key_ttl_seconds(self) -> float | None:
+        return self._key_ttl_seconds
+
+    def purge_session(self, session_id: str) -> int:
+        """Drop all idempotency keys for one session; return the count.
+
+        Called when a session is discarded or finalized so a rebuilt
+        session reusing the same id (and step indexes) is not wrongly
+        suppressed as a duplicate.
+        """
+
+        return len(self._seen_keys.pop(session_id, None) or {})
+
+    def _applicable(self, ctx: ToolCallContext) -> list[ToolCallHook]:
+        applicable: list[ToolCallHook] = []
+        for hook in self._hooks:
+            try:
+                if hook.applies_to(ctx):
+                    applicable.append(hook)
+            except Exception:
+                logger.warning(
+                    "tool-call hook %s applies_to() failed; skipping hook",
+                    type(hook).__name__,
+                    exc_info=True,
+                )
+        return applicable
+
+    def _claim_idempotency(self, ctx: ToolCallContext) -> bool:
+        """Return True when this key has not been dispatched yet."""
+
+        key = ctx.idempotency_key
+        if not key:
+            return True
+        now = time.monotonic()
+        self._maybe_prune(now)
+        session_keys = self._seen_keys.setdefault(ctx.session_id, {})
+        claimed_at = session_keys.get(key)
+        if claimed_at is not None and not self._expired(claimed_at, now):
+            return False
+        session_keys[key] = now
+        return True
+
+    def _expired(self, claimed_at: float, now: float) -> bool:
+        if self._key_ttl_seconds is None:
+            return False
+        return (now - claimed_at) >= self._key_ttl_seconds
+
+    def _maybe_prune(self, now: float) -> None:
+        """Lazily evict expired keys at most once per prune interval.
+
+        Each round scans at most ``_PRUNE_MAX_KEYS_PER_ROUND`` keys so a
+        very large key store cannot stall the dispatch hot path; the
+        next round resumes from where this one stopped.
+        """
+
+        if self._key_ttl_seconds is None:
+            return
+        if now - self._last_prune < _PRUNE_INTERVAL_SECONDS:
+            return
+        self._last_prune = now
+        scanned = 0
+        for session_id, keys in list(self._seen_keys.items()):
+            if scanned >= _PRUNE_MAX_KEYS_PER_ROUND:
+                break
+            for key, claimed_at in list(keys.items()):
+                if scanned >= _PRUNE_MAX_KEYS_PER_ROUND:
+                    break
+                scanned += 1
+                if self._expired(claimed_at, now):
+                    keys.pop(key, None)
+            if not keys:
+                self._seen_keys.pop(session_id, None)
+
+    async def run_before(self, ctx: ToolCallContext) -> None:
+        if not self._claim_idempotency(ctx):
+            logger.debug(
+                "skipping duplicate before_tool_call dispatch: key=%s",
+                ctx.idempotency_key,
+            )
+            return
+        for hook in self._applicable(ctx):
+            await self._run_one(hook, hook.before_tool_call, ctx, stage="before")
+
+    async def run_after(self, ctx: ToolCallContext) -> None:
+        if not self._claim_idempotency(ctx):
+            logger.debug(
+                "skipping duplicate after_tool_call dispatch: key=%s",
+                ctx.idempotency_key,
+            )
+            return
+        for hook in reversed(self._applicable(ctx)):
+            await self._run_one(hook, hook.after_tool_call, ctx, stage="after")
+
+    async def _run_one(
+        self,
+        hook: ToolCallHook,
+        method: Any,
+        ctx: ToolCallContext,
+        *,
+        stage: str,
+    ) -> None:
+        label = f"{type(hook).__name__}({getattr(hook, 'name', '')})"
+        try:
+            coro = method(ctx)
+            if self._before_timeout is not None and stage == "before":
+                await asyncio.wait_for(coro, timeout=self._before_timeout)
+            else:
+                await coro
+        except asyncio.TimeoutError as exc:
+            self._record_failure(
+                ctx,
+                hook,
+                stage,
+                exc,
+                timed_out=True,
+                timeout_seconds=self._before_timeout,
+            )
+            if hook.required:
+                raise ToolCallHookError(
+                    f"required tool-call hook {label} timed out after "
+                    f"{self._before_timeout}s at stage={stage}"
+                ) from exc
+            logger.warning(
+                "optional tool-call hook %s timed out after %ss at stage=%s; "
+                "continuing: session_id=%s",
+                label,
+                self._before_timeout,
+                stage,
+                ctx.session_id,
+            )
+        except Exception as exc:
+            self._record_failure(ctx, hook, stage, exc)
+            if hook.required:
+                raise ToolCallHookError(
+                    f"required tool-call hook {label} failed at stage={stage}: {exc}"
+                ) from exc
+            logger.warning(
+                "optional tool-call hook %s failed at stage=%s; continuing: "
+                "session_id=%s error=%s",
+                label,
+                stage,
+                ctx.session_id,
+                exc,
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _record_failure(
+        ctx: ToolCallContext,
+        hook: ToolCallHook,
+        stage: str,
+        exc: BaseException,
+        *,
+        timed_out: bool = False,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        record = {
+            "hook": getattr(hook, "name", "") or type(hook).__name__,
+            "stage": stage,
+            "required": bool(hook.required),
+            "error": {
+                "type": f"{type(exc).__module__}.{type(exc).__name__}",
+                "message": str(exc) or "timeout",
+            },
+        }
+        if timed_out:
+            record["timed_out"] = True
+            if timeout_seconds is not None:
+                record["timeout_seconds"] = timeout_seconds
+        ctx.stage_metadata.setdefault("tool_call_hook_failures", []).append(record)

--- a/examples/tool_call_hooks_example.py
+++ b/examples/tool_call_hooks_example.py
@@ -1,0 +1,192 @@
+"""Example tool-call hooks for Dressage blackbox rollouts.
+
+This file demonstrates the most common hook patterns.  Enable any of them
+with the proxy CLI::
+
+    dressage-proxy --tokenizer-path ... \\
+        --tool-call-hooks examples/tool_call_hooks_example.py:E2BSnapshotHook \\
+        --tool-call-hook-before-timeout 5.0
+
+Reference forms accepted by ``--tool-call-hooks``:
+
+- ``E2BSnapshotHook``            (a name already registered at import time)
+- ``examples.tool_call_hooks_example:E2BSnapshotHook``  (module:Class)
+- ``examples/tool_call_hooks_example.py:E2BSnapshotHook`` (path:Class)
+- ``examples/tool_call_hooks_example.py`` (bare path; only valid when the
+  file registers exactly one hook — this file registers four, so qualify
+  the class name)
+
+The e2b examples import the SDK lazily so this file stays importable in
+environments without ``e2b`` installed (e.g. CI running the unit tests).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import ClassVar
+
+from dressage.proxy.tool_call_hooks import (
+    ToolCallContext,
+    ToolCallHook,
+    register_tool_call_hook,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Example 1: e2b sandbox snapshot after every tool round
+# ---------------------------------------------------------------------------
+
+
+@register_tool_call_hook
+class E2BSnapshotHook(ToolCallHook):
+    """Take a snapshot point after each tool execution round.
+
+    ``after_tool_call`` fires when a request's normalized message tail is a
+    ``role=tool`` message, i.e. the previous step's tools already ran inside
+    the sandbox.  The hook reconnects to the sandbox with the provider-native
+    id and records a snapshot marker; results written to
+    ``ctx.stage_metadata`` land in the finalized trajectory under
+    ``extra_info["tool_call_hooks"]``.
+    """
+
+    name = "e2b_snapshot"
+    required = False  # snapshot failures must not abort the rollout
+    order = 100
+
+    def __init__(self) -> None:
+        self._snapshots = 0
+
+    async def after_tool_call(self, ctx: ToolCallContext) -> None:
+        from e2b import AsyncSandbox  # lazy import; optional dependency
+
+        started = time.monotonic()
+        sandbox = await AsyncSandbox.connect(ctx.sandbox_id)
+        try:
+            # Replace with a real snapshot call for your setup, e.g. an e2b
+            # template snapshot or a filesystem checkpoint command:
+            await sandbox.commands.run("sync", timeout=10)
+        finally:
+            await sandbox.disconnect()
+        self._snapshots += 1
+        ctx.stage_metadata["e2b_snapshot"] = {
+            "sandbox_id": ctx.sandbox_id,
+            "step_index": ctx.step_index,
+            "elapsed_ms": round((time.monotonic() - started) * 1000, 2),
+            "total_snapshots": self._snapshots,
+        }
+        logger.info(
+            "e2b snapshot taken: session=%s step=%d sandbox=%s",
+            ctx.session_id,
+            ctx.step_index,
+            ctx.sandbox_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Example 2: restore sandbox networking right before tools execute
+# ---------------------------------------------------------------------------
+
+
+@register_tool_call_hook
+class RestoreNetworkHook(ToolCallHook):
+    """Re-enable sandbox egress just before the agent executes tools.
+
+    ``before_tool_call`` fires synchronously *before* the tool_calls
+    response is returned to the agent, so the sandbox is guaranteed to be
+    ready by the time the tools actually run.  ``required=True`` makes a
+    failure abort the request (HTTP 502) instead of letting the agent run
+    tools against a sandbox that is still network-isolated.
+    """
+
+    name = "restore_network"
+    required = True
+    order = 10  # run before snapshot-style hooks
+
+    async def before_tool_call(self, ctx: ToolCallContext) -> None:
+        from e2b import AsyncSandbox
+
+        sandbox = await AsyncSandbox.connect(ctx.sandbox_id)
+        try:
+            # Example: flip a state file that the sandbox's egress wrapper
+            # sources.  Adapt to your own networking setup.
+            await sandbox.files.write("/etc/dressage/network_state", "online\n")
+        finally:
+            await sandbox.disconnect()
+        ctx.stage_metadata["network_restored"] = {
+            "sandbox_id": ctx.sandbox_id,
+            "tools": [tc["function"]["name"] for tc in ctx.tool_calls or []],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Example 3: selective observability — only watch one tool
+# ---------------------------------------------------------------------------
+
+
+@register_tool_call_hook
+class ToolWatchHook(ToolCallHook):
+    """Record every invocation of one specific tool.
+
+    Demonstrates ``applies_to`` filtering and reading parsed tool calls from
+    the context.  Steps that do not match skip this hook entirely.
+    """
+
+    name = "tool_watch"
+    required = False
+    order = 200
+
+    watched_tool: ClassVar[str] = "web_search"
+
+    def applies_to(self, ctx: ToolCallContext) -> bool:
+        # Only before-stage contexts carry tool_calls; after-stage contexts
+        # (tool_calls=None) are filtered out here.
+        return any(
+            tc.get("function", {}).get("name") == self.watched_tool
+            for tc in ctx.tool_calls or []
+        )
+
+    async def before_tool_call(self, ctx: ToolCallContext) -> None:
+        calls = [
+            tc["function"]
+            for tc in ctx.tool_calls or []
+            if tc.get("function", {}).get("name") == self.watched_tool
+        ]
+        ctx.stage_metadata.setdefault("watched_calls", []).extend(
+            {
+                "tool": self.watched_tool,
+                "arguments": call.get("arguments"),
+                "step_index": ctx.step_index,
+            }
+            for call in calls
+        )
+
+
+# ---------------------------------------------------------------------------
+# Example 4: a no-provider hook that only records timing metrics
+# ---------------------------------------------------------------------------
+
+
+@register_tool_call_hook
+class StepTimingHook(ToolCallHook):
+    """Pure observability: measure tool-round cadence per session.
+
+    Needs no sandbox access at all — useful for smoke-testing the hook
+    pipeline in local runs before wiring real side effects.
+    """
+
+    name = "step_timing"
+    required = False
+    order = 500
+
+    def __init__(self) -> None:
+        self._last_seen: dict[str, float] = {}
+
+    async def after_tool_call(self, ctx: ToolCallContext) -> None:
+        now = time.monotonic()
+        previous = self._last_seen.get(ctx.session_id)
+        self._last_seen[ctx.session_id] = now
+        if previous is not None:
+            ctx.stage_metadata["tool_round_gap_seconds"] = round(now - previous, 3)

--- a/tests/test_tool_call_hooks.py
+++ b/tests/test_tool_call_hooks.py
@@ -1,0 +1,780 @@
+"""Tests for blackbox tool-call side-effect hooks."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from dressage.proxy.server import create_app
+from dressage.proxy.session_manager import SessionManager
+from dressage.proxy.tool_call_hooks import (
+    ToolCallContext,
+    ToolCallHook,
+    ToolCallHookChain,
+    ToolCallHookError,
+    build_tool_call_hook_chain,
+    build_tool_call_idempotency_key,
+    load_tool_call_hooks,
+    register_tool_call_hook,
+    registered_tool_call_hooks,
+    reset_tool_call_hook_registry,
+)
+from dressage.proxy.trajectory_store import TrajectoryStore
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class RecordingHook(ToolCallHook):
+    name = "recording"
+    order = 100
+
+    def __init__(self) -> None:
+        self.before_events: list[ToolCallContext] = []
+        self.after_events: list[ToolCallContext] = []
+
+    async def before_tool_call(self, ctx: ToolCallContext) -> None:
+        self.before_events.append(ctx)
+
+    async def after_tool_call(self, ctx: ToolCallContext) -> None:
+        self.after_events.append(ctx)
+
+
+class FailingHook(ToolCallHook):
+    name = "failing"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def before_tool_call(self, ctx: ToolCallContext) -> None:
+        self.calls += 1
+        raise RuntimeError("boom")
+
+
+class SlowHook(ToolCallHook):
+    name = "slow"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def before_tool_call(self, ctx: ToolCallContext) -> None:
+        self.calls += 1
+        await asyncio.sleep(10)
+
+
+class SelectiveHook(RecordingHook):
+    name = "selective"
+    order = 50
+
+    def applies_to(self, ctx: ToolCallContext) -> bool:
+        return ctx.session_id == "sess-hooks"
+
+
+class FakeTokenizer:
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tokenize,
+        add_generation_prompt,
+        return_dict,
+        tools=None,
+        chat_template=None,
+        return_assistant_tokens_mask=False,
+        **_,
+    ):
+        rendered = ""
+        masks: list[int] = []
+        for message in messages:
+            role = message.get("role", "unknown")
+            chunk = f"<{role}>"
+            rendered += chunk
+            masks.extend([0] * len(chunk))
+            content = message.get("content")
+            if content is not None:
+                text = str(content)
+                rendered += text
+                if role == "assistant":
+                    masks.extend([1] * len(text))
+                else:
+                    masks.extend([0] * len(text))
+        if add_generation_prompt:
+            rendered += "<assistant>"
+            masks.extend([0] * len("<assistant>"))
+        if not tokenize:
+            return rendered
+        payload = {"input_ids": [ord(ch) for ch in rendered]}
+        if return_assistant_tokens_mask:
+            payload["assistant_masks"] = list(masks)
+        return payload if return_dict else payload["input_ids"]
+
+
+class _FakeResponse:
+    def __init__(self, text: str):
+        self.output_ids = [ord(ch) for ch in text]
+        self.output_token_logprobs = [-0.1 for _ in text]
+        self.output_token_texts = list(text)
+        self.text = text
+        self.meta_info: dict[str, Any] = {}
+        self.finish_reason = "stop"
+        self.input_token_logprobs_raw = []
+        self.all_token_ids = list(self.output_ids)
+        self.all_logprobs = list(self.output_token_logprobs)
+        self.output_versions: list[str] = []
+        self.weight_version = "v1"
+        self.rollout_epoch = 1
+        self.all_logprobs_invalid = False
+        self.input_token_texts: list[str] = []
+        self.routed_experts_chunks: list[Any] = []
+
+
+class FakeSGLangClient:
+    def __init__(self, responses: list[str]):
+        self._responses = list(responses)
+
+    async def generate(self, input_ids, sampling_params, **kwargs):
+        text = self._responses.pop(0)
+        return _FakeResponse(text)
+
+    async def parse_function_call(self, text, tools=None, **kwargs):
+        if "<tool_call>" in text:
+            payload = json.loads(text.split("<tool_call>")[1].split("</tool_call>")[0])
+            return {
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call000001",
+                        "type": "function",
+                        "index": 0,
+                        "function": {
+                            "name": payload["name"],
+                            "arguments": json.dumps(payload["arguments"]),
+                        },
+                    }
+                ],
+            }
+        return {"content": text, "tool_calls": None}
+
+    async def separate_reasoning(self, text, **kwargs):
+        return {"reasoning_content": None, "content": text}
+
+    async def close(self) -> None:
+        return None
+
+
+def make_hook_client(
+    *responses: str,
+    chain: ToolCallHookChain | None,
+) -> tuple[TestClient, SessionManager]:
+    session_manager = SessionManager()
+    app = create_app(
+        sglang_router_url="http://router.test",
+        tokenizer=FakeTokenizer(),
+        session_manager=session_manager,
+        trajectory_store=TrajectoryStore(min_group_size=1, group_timeout=0.0),
+        sglang_client=FakeSGLangClient(list(responses)),
+        model_mask_type="qwen3_5",
+        model_tool_call_type="hermes",
+        tool_call_parse_backend="local",
+        token_build_mode="snapshot",
+        tool_call_hook_chain=chain,
+    )
+    return TestClient(app), session_manager
+
+
+# ---------------------------------------------------------------------------
+# Chain semantics
+# ---------------------------------------------------------------------------
+
+
+def _ctx(session_id: str = "sess-1", **overrides: Any) -> ToolCallContext:
+    defaults: dict[str, Any] = {
+        "instance_id": "inst-1",
+        "session_id": session_id,
+        "turn_id": "turn-1",
+        "step_index": 0,
+        "sandbox_id": "sbx-1",
+    }
+    defaults.update(overrides)
+    return ToolCallContext(**defaults)
+
+
+def test_chain_runs_before_ascending_and_after_descending():
+    order_log: list[str] = []
+
+    class Ordered(ToolCallHook):
+        def __init__(self, name: str, order: int) -> None:
+            self.name = name
+            self.order = order
+
+        async def before_tool_call(self, ctx) -> None:
+            order_log.append(f"before:{self.name}")
+
+        async def after_tool_call(self, ctx) -> None:
+            order_log.append(f"after:{self.name}")
+
+    chain = ToolCallHookChain([Ordered("c", 300), Ordered("a", 100), Ordered("b", 200)])
+    asyncio.run(chain.run_before(_ctx()))
+    asyncio.run(chain.run_after(_ctx()))
+
+    assert order_log == [
+        "before:a",
+        "before:b",
+        "before:c",
+        "after:c",
+        "after:b",
+        "after:a",
+    ]
+
+
+def test_optional_hook_failure_is_recorded_and_chain_continues():
+    hook = FailingHook()
+    recorder = RecordingHook()
+    chain = ToolCallHookChain([hook, recorder])
+    metadata: dict[str, Any] = {}
+    ctx = _ctx(stage_metadata=metadata)
+
+    asyncio.run(chain.run_before(ctx))
+
+    assert hook.calls == 1
+    assert len(recorder.before_events) == 1
+    failures = metadata["tool_call_hook_failures"]
+    assert failures[0]["hook"] == "failing"
+    assert failures[0]["required"] is False
+    assert "boom" in failures[0]["error"]["message"]
+
+
+def test_required_hook_failure_raises():
+    class RequiredFailing(FailingHook):
+        name = "required-failing"
+        required = True
+
+    chain = ToolCallHookChain([RequiredFailing()])
+    with pytest.raises(ToolCallHookError):
+        asyncio.run(chain.run_before(_ctx()))
+
+
+def test_before_timeout_applies_to_before_stage():
+    class RequiredSlow(SlowHook):
+        name = "required-slow"
+        required = True
+
+    chain = ToolCallHookChain([RequiredSlow()], before_timeout=0.05)
+    with pytest.raises(ToolCallHookError):
+        asyncio.run(chain.run_before(_ctx()))
+    assert chain.before_timeout == 0.05
+
+
+def test_idempotency_key_suppresses_duplicate_dispatches():
+    recorder = RecordingHook()
+    chain = ToolCallHookChain([recorder])
+    key = build_tool_call_idempotency_key(
+        session_id="s", turn_id="t", step_index=1, stage="before"
+    )
+    ctx = _ctx(idempotency_key=key)
+
+    asyncio.run(chain.run_before(ctx))
+    asyncio.run(chain.run_before(ctx))
+
+    assert len(recorder.before_events) == 1
+
+
+def test_applies_to_filters_hooks():
+    selective = SelectiveHook()
+    chain = ToolCallHookChain([selective])
+    asyncio.run(chain.run_before(_ctx(session_id="other-session")))
+    assert selective.before_events == []
+    asyncio.run(chain.run_before(_ctx(session_id="sess-hooks")))
+    assert len(selective.before_events) == 1
+
+
+def test_idempotency_keys_expire_after_ttl():
+    recorder = RecordingHook()
+    chain = ToolCallHookChain([recorder], key_ttl_seconds=0.0)
+    key = build_tool_call_idempotency_key(
+        session_id="s", turn_id="t", step_index=1, stage="before"
+    )
+    ctx = _ctx(idempotency_key=key)
+
+    asyncio.run(chain.run_before(ctx))
+    asyncio.run(chain.run_before(ctx))
+
+    # ttl=0 means every claim is fresh: the second dispatch is NOT a
+    # duplicate and both run.
+    assert len(recorder.before_events) == 2
+
+
+def test_purge_session_releases_keys_for_rebuilt_sessions():
+    recorder = RecordingHook()
+    chain = ToolCallHookChain([recorder])
+    key = build_tool_call_idempotency_key(
+        session_id="sess-rebuild", turn_id="t", step_index=0, stage="before"
+    )
+    ctx = _ctx(session_id="sess-rebuild", idempotency_key=key)
+
+    asyncio.run(chain.run_before(ctx))
+    asyncio.run(chain.run_before(ctx))
+    assert len(recorder.before_events) == 1
+
+    assert chain.purge_session("sess-rebuild") == 1
+    assert chain.purge_session("sess-rebuild") == 0  # idempotent
+
+    # After discard the same key dispatches again (rebuilt session).
+    asyncio.run(chain.run_before(ctx))
+    assert len(recorder.before_events) == 2
+
+
+def test_discard_endpoint_purges_hook_keys():
+    hook = RecordingHook()
+    client, _ = make_hook_client(
+        TOOL_CALL_TEXT,
+        chain=ToolCallHookChain([hook]),
+    )
+    headers = {
+        "X-Session-Id": "sess-purge",
+        "X-Instance-Id": "inst-1",
+        "X-Dressage-Sandbox-Id": "sbx-1",
+    }
+    first = client.post(
+        "/v1/chat/completions",
+        headers=headers,
+        json={
+            "model": "fake-model",
+            "messages": [{"role": "user", "content": "find x"}],
+        },
+    )
+    assert first.status_code == 200
+    assert len(hook.before_events) == 1
+
+    discarded = client.post("/session/discard", json={"session_id": "sess-purge"})
+    assert discarded.status_code == 200
+    assert discarded.json()["tool_call_hook_keys_purged"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Registry / loader
+# ---------------------------------------------------------------------------
+
+
+def test_registry_decorator_and_duplicate_rejection():
+    reset_tool_call_hook_registry()
+    try:
+
+        @register_tool_call_hook
+        class Decorated(RecordingHook):
+            name = "decorated"
+
+        assert "decorated" in registered_tool_call_hooks()
+        with pytest.raises(ValueError):
+
+            @register_tool_call_hook
+            class Conflicting(RecordingHook):
+                name = "decorated"
+
+        hooks = load_tool_call_hooks(["decorated"])
+        assert len(hooks) == 1
+        assert isinstance(hooks[0], Decorated)
+        with pytest.raises(ValueError):
+            load_tool_call_hooks(["missing-hook"])
+    finally:
+        reset_tool_call_hook_registry()
+
+
+def test_load_hooks_from_file_path(tmp_path):
+    hook_file = tmp_path / "my_snapshot_hook.py"
+    hook_file.write_text(
+        "from dressage.proxy.tool_call_hooks import ToolCallHook, "
+        "register_tool_call_hook\n"
+        "\n"
+        "\n"
+        "@register_tool_call_hook\n"
+        "class FileHook(ToolCallHook):\n"
+        "    name = 'file-hook'\n",
+        encoding="utf-8",
+    )
+    reset_tool_call_hook_registry()
+    try:
+        hooks = load_tool_call_hooks([f"{hook_file}:FileHook"])
+        assert hooks[0].name == "file-hook"
+        # Bare path works when the file registers exactly one hook.
+        hooks = load_tool_call_hooks([str(hook_file)])
+        assert hooks[0].name == "file-hook"
+    finally:
+        reset_tool_call_hook_registry()
+
+
+def test_build_chain_returns_none_without_hooks():
+    assert build_tool_call_hook_chain(None) is None
+    assert build_tool_call_hook_chain([]) is None
+    assert build_tool_call_hook_chain([RecordingHook()]) is not None
+
+
+# ---------------------------------------------------------------------------
+# Proxy pipeline integration
+# ---------------------------------------------------------------------------
+
+
+TOOL_CALL_TEXT = '<tool_call>{"name": "search", "arguments": {"q": "x"}}</tool_call>'
+
+
+def test_hooks_dispatch_on_tool_boundaries():
+    hook = RecordingHook()
+    client, session_manager = make_hook_client(
+        TOOL_CALL_TEXT,
+        "done",
+        chain=ToolCallHookChain([hook]),
+    )
+
+    first = client.post(
+        "/v1/chat/completions",
+        headers={
+            "X-Session-Id": "sess-hooks",
+            "X-Instance-Id": "inst-1",
+            "X-Dressage-Sandbox-Id": "sbx-e2b-1",
+        },
+        json={
+            "model": "fake-model",
+            "messages": [{"role": "user", "content": "find x"}],
+        },
+    )
+    assert first.status_code == 200
+    assert first.json()["choices"][0]["finish_reason"] == "tool_calls"
+
+    # before_tool_call fired once for the parsed tool_calls of step 0.
+    assert len(hook.before_events) == 1
+    before_ctx = hook.before_events[0]
+    assert before_ctx.session_id == "sess-hooks"
+    assert before_ctx.sandbox_id == "sbx-e2b-1"
+    assert before_ctx.tool_calls[0]["function"]["name"] == "search"
+    assert hook.after_events == []
+
+    # Second request carries the tool result -> after_tool_call fires.
+    session = session_manager.get_session("sess-hooks")
+    tool_call_id = session.full_messages[-1]["tool_calls"][0]["id"]
+    second = client.post(
+        "/v1/chat/completions",
+        headers={
+            "X-Session-Id": "sess-hooks",
+            "X-Instance-Id": "inst-1",
+            "X-Dressage-Sandbox-Id": "sbx-e2b-1",
+        },
+        json={
+            "model": "fake-model",
+            "messages": session.full_messages
+            + [
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": "result",
+                }
+            ],
+        },
+    )
+    assert second.status_code == 200
+    assert len(hook.after_events) == 1
+    assert hook.after_events[0].session_id == "sess-hooks"
+    # Step 1 also produced plain text (no tool_calls) -> no extra before.
+    assert len(hook.before_events) == 1
+
+
+def test_hook_metadata_lands_in_finalized_trajectory():
+    class MetadataHook(RecordingHook):
+        name = "metadata-hook"
+
+        async def before_tool_call(self, ctx: ToolCallContext) -> None:
+            ctx.stage_metadata["before_snapshot"] = {"sandbox_id": ctx.sandbox_id}
+            await super().before_tool_call(ctx)
+
+    hook = MetadataHook()
+    client, session_manager = make_hook_client(
+        TOOL_CALL_TEXT,
+        "done",
+        chain=ToolCallHookChain([hook]),
+    )
+    headers = {
+        "X-Session-Id": "sess-meta",
+        "X-Instance-Id": "inst-1",
+        "X-Dressage-Sandbox-Id": "sbx-meta",
+    }
+    first = client.post(
+        "/v1/chat/completions",
+        headers=headers,
+        json={
+            "model": "fake-model",
+            "messages": [{"role": "user", "content": "find x"}],
+        },
+    )
+    assert first.status_code == 200
+    session = session_manager.get_session("sess-meta")
+    tool_call_id = session.full_messages[-1]["tool_calls"][0]["id"]
+    second = client.post(
+        "/v1/chat/completions",
+        headers=headers,
+        json={
+            "model": "fake-model",
+            "messages": session.full_messages
+            + [
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": "result",
+                }
+            ],
+        },
+    )
+    assert second.status_code == 200
+
+    finalized = client.post(
+        "/session/finalize",
+        json={"session_id": "sess-meta", "instance_id": "inst-1"},
+    )
+    assert finalized.status_code == 200
+    read = client.post("/trajectory/read", json={"trajectory_id": "sess-meta"})
+    items = read.json()["data"]
+    assert items, "expected finalized trajectory segments"
+    step0 = next(
+        item
+        for item in items
+        if item.get("extra_info", {}).get("segment_view") == "timeline"
+        and "tool_call_hooks" in item.get("extra_info", {})
+    )
+    hooks_meta = step0["extra_info"]["tool_call_hooks"]
+    assert hooks_meta["before_snapshot"] == {"sandbox_id": "sbx-meta"}
+
+
+def test_no_chain_is_full_noop():
+    client, _ = make_hook_client("hello", chain=None)
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"X-Session-Id": "sess-noop"},
+        json={
+            "model": "fake-model",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_required_hook_failure_returns_502():
+    class RequiredFailing(FailingHook):
+        name = "required-failing"
+        required = True
+
+    client, _ = make_hook_client(
+        TOOL_CALL_TEXT,
+        chain=ToolCallHookChain([RequiredFailing()]),
+    )
+    response = client.post(
+        "/v1/chat/completions",
+        headers={
+            "X-Session-Id": "sess-fail",
+            "X-Dressage-Sandbox-Id": "sbx-1",
+        },
+        json={
+            "model": "fake-model",
+            "messages": [{"role": "user", "content": "find x"}],
+        },
+    )
+    assert response.status_code == 502
+    assert response.json()["detail"]["error"] == "tool_call_hook_failed"
+    assert response.json()["detail"]["stage"] == "before"
+
+
+def test_missing_sandbox_id_skips_dispatch():
+    hook = RecordingHook()
+    client, _ = make_hook_client(
+        TOOL_CALL_TEXT,
+        chain=ToolCallHookChain([hook]),
+    )
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"X-Session-Id": "sess-nosbx"},
+        json={
+            "model": "fake-model",
+            "messages": [{"role": "user", "content": "find x"}],
+        },
+    )
+    assert response.status_code == 200
+    assert hook.before_events == []
+    assert hook.after_events == []
+
+
+# ---------------------------------------------------------------------------
+# RolloutLLMProxy header forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_rollout_proxy_forwards_bound_sandbox_id_header():
+    from blackbox_server.proxy.rollout_llm_proxy import RolloutLLMProxy
+
+    proxy = RolloutLLMProxy(
+        upstream_origin="http://127.0.0.1:8800",
+        router_api_path="/v1",
+        bound_session_id="sess-001",
+        bound_instance_id="inst-001",
+        bound_sandbox_id="sbx-e2b-42",
+        sticky_header_name="X-SMG-Routing-Key",
+    )
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp-1",
+                "choices": [{"message": {"role": "assistant", "content": "OK"}}],
+            },
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "proxy-model",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        await proxy.drain_turn(timeout=1.0)
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+        assert response.status_code == 200
+
+    asyncio.run(run_test())
+
+    assert captured["headers"]["x-dressage-sandbox-id"] == "sbx-e2b-42"
+    assert captured["headers"]["x-session-id"] == "sess-001"
+
+
+def test_rollout_proxy_omits_header_without_sandbox_id():
+    from blackbox_server.proxy.rollout_llm_proxy import RolloutLLMProxy
+
+    proxy = RolloutLLMProxy(
+        upstream_origin="http://127.0.0.1:8800",
+        router_api_path="/v1",
+        bound_session_id="sess-001",
+        bound_instance_id="inst-001",
+        sticky_header_name="X-SMG-Routing-Key",
+    )
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp-1",
+                "choices": [{"message": {"role": "assistant", "content": "OK"}}],
+            },
+        )
+
+    async def run_test() -> None:
+        proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await proxy.open_turn("turn-001")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=proxy.app),
+            base_url="http://proxy",
+        ) as client:
+            await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "proxy-model",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        await proxy.drain_turn(timeout=1.0)
+        await proxy.clear_turn()
+        await proxy._client.aclose()
+
+    asyncio.run(run_test())
+
+    assert "x-dressage-sandbox-id" not in captured["headers"]
+
+
+# ---------------------------------------------------------------------------
+# Register binding plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_register_request_accepts_bound_sandbox_id():
+    from blackbox_server.core.models import RegisterRequest
+
+    request = RegisterRequest(
+        blackbox_type="opencode",
+        router="http://127.0.0.1:8800",
+        bound_session_id="sess-1",
+        bound_instance_id="inst-1",
+        bound_sandbox_id="sbx-1",
+    )
+    assert request.bound_sandbox_id == "sbx-1"
+
+    default_request = RegisterRequest(
+        blackbox_type="opencode",
+        router="http://127.0.0.1:8800",
+        bound_session_id="sess-1",
+        bound_instance_id="inst-1",
+    )
+    assert default_request.bound_sandbox_id is None
+
+
+def test_blackbox_client_register_payload_carries_sandbox_id():
+    from dressage.paddock.blackbox.client import BlackboxServerClient
+    from dressage.sandbox.types import SandboxEndpoint
+
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["json"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"ok": True})
+
+    async def run_test() -> None:
+        client = BlackboxServerClient(
+            client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        )
+        await client.register_agent(
+            SandboxEndpoint(url="http://sandbox.test"),
+            trajectory_id="traj-1",
+            instance_id="inst-1",
+            session_id="sess-1",
+            router_url="http://proxy.test",
+            blackbox_type="opencode",
+            backend_options={},
+            server_config={},
+            sandbox_id="sbx-native-1",
+        )
+        await client._client.aclose()
+
+    asyncio.run(run_test())
+
+    assert captured["json"]["bound_sandbox_id"] == "sbx-native-1"
+
+
+def test_binding_fingerprint_distinguishes_sandbox_id():
+    from blackbox_server.core.hashing import binding_request_fingerprint
+    from blackbox_server.core.models import RegisterRequest
+
+    base = {
+        "blackbox_type": "opencode",
+        "router": "http://127.0.0.1:8800",
+        "bound_session_id": "sess-1",
+        "bound_instance_id": "inst-1",
+    }
+    without_sandbox = RegisterRequest(**base)
+    with_sandbox = RegisterRequest(**base, bound_sandbox_id="sbx-1")
+
+    assert binding_request_fingerprint(
+        without_sandbox, "http://127.0.0.1:8800"
+    ) != binding_request_fingerprint(with_sandbox, "http://127.0.0.1:8800")


### PR DESCRIPTION
## Summary
fix part of #31 
This PR adds a pluggable tool-call hook layer to the Dressage proxy, enabling side effects at blackbox agent tool-execution boundaries. Two hook points are derived from a single /chat/completions request: after_tool_call (the previous step's tools already executed inside the sandbox) and before_tool_call (parsed tool_calls are about to execute). Hooks are side-effect only, opt-in, and provider-agnostic; when nothing is configured the feature is a zero-cost no-op. Typical use cases include sandbox snapshotting, network policy toggling, and per-step observability correlated with the training trajectory.

## Motivation
During blackbox rollouts (opencode / claude_code / codex agents running inside sandboxes), several workflows need to run side effects at tool-execution boundaries:

* Sandbox snapshotting — capture sandbox state after each tool round for post-hoc analysis, reward computation, or reproducible debugging.
* Network policy toggling — keep sandboxes network-isolated by default and restore egress only while tools that need connectivity are about to run.
* Per-step observability — record which tools ran, when, and how long the gaps between tool rounds are.

The Dressage proxy is the natural observation point: it already normalizes all agent protocols (Anthropic Messages, OpenAI Responses, OpenAI chat) into a single OpenAI chat format, so role=tool messages and parsed tool_calls are agent-agnostic. The proxy never sees actual tool execution — only the request stream — so the hook layer is placed at the two observable step boundaries without coupling the proxy to any specific sandbox provider.

## Changes / Design
New module dressage/proxy/tool_call_hooks.py:

* ToolCallContext: frozen dataclass carrying the rollout hierarchy (instance_id > session_id > turn_id > step_index), the provider-native sandbox_id, parsed tool_calls, an idempotency key, and a stage_metadata dict for hook results.
* ToolCallHook: abstract base with name / required / order class vars, applies_to filtering, and async before_tool_call / after_tool_call methods.
* ToolCallHookChain: dispatcher running before-hooks in ascending order and after-hooks in descending order. Required-hook failures (or before-stage timeout) raise ToolCallHookError; optional failures are logged, recorded into stage metadata, and the chain continues.
* Registry + loader: hooks register via decorator or subclass scan; entries may be registered names, module:ClassName, /path/file.py:ClassName, or a bare file path that registers exactly one hook. Loading is run-level (one chain for the whole proxy lifetime) and fails fast on bad references.
* Idempotency: each dispatch claims a session:turn:step:stage key; duplicate dispatches (HTTP retries, partial-rollout replays) are skipped. Keys are purged on session finalize/discard and expire after a TTL (default 1h) as a leak backstop.
Proxy integration (dressage/proxy/server.py):

* after_tool_call fires when the normalized request messages end with a role=tool message; before_tool_call fires when the response contains non-empty parsed tool_calls, before the response is returned (runs synchronously so the agent is guaranteed a prepared sandbox).
* Required-hook failures abort the request with HTTP 502 so the agent never executes tools against an unprepared sandbox.
* Hook results land in StepRecord.tool_call_hook_metadata and are persisted into finalized trajectory segments under extra_info["tool_call_hooks"].
* New CLI flags: --tool-call-hooks and --tool-call-hook-before-timeout.
sandbox_id plumbing (required for e2b reconnect):

* paddock.init() lease.sandbox_id → register payload bound_sandbox_id (dressage/paddock/blackbox/client.py, paddock.py) → BindingInfo.bound_sandbox_id (blackbox_server/core/models.py) → RolloutLLMProxy(bound_sandbox_id=...) in all four adapters → X-Dressage-Sandbox-Id header per LLM request (blackbox_server/proxy/rollout_llm_proxy.py) → proxy parses the header into ctx.sandbox_id.
* The header is reserved: client-supplied values are stripped, so in-sandbox agents cannot spoof it.
* bound_sandbox_id participates in the register fingerprint (blackbox_server/core/hashing.py), so a changed sandbox id triggers a full rebind instead of an idempotent replay of a stale binding.
Example hooks (examples/tool_call_hooks_example.py): four documented, ready-to-use hooks — e2b snapshot, network restore, selective watch, and per-step timing.

Design doc: docs/tool_call_hooks_proposal.md.

## Compatibility
* Fully backward compatible and opt-in: with no --tool-call-hooks configured, the chain is None and dispatch is a zero-cost no-op; existing rollouts are unaffected.
* RegisterRequest / BindingInfo gain an optional bound_sandbox_id field (default None); older clients that omit it continue to work unchanged.
* StepRecord.tool_call_hook_metadata has a default factory; existing serialized step data is unaffected.
* One behavioral note: because bound_sandbox_id now participates in the register fingerprint, the first register after upgrade — from a client that starts sending a sandbox id — will trigger one full rebind. This is intended, to avoid replaying a stale binding.
* X-Dressage-Sandbox-Id is a newly reserved header; any client-supplied value is stripped before forwarding.
## Validation
22 new tests in tests/test_tool_call_hooks.py covering:

* Chain semantics: before ascending / after descending ordering, optional-failure recording and continuation, required-failure propagation, before-stage timeout, applies_to filtering.
* Idempotency: duplicate dispatch suppression, TTL expiry, key release on session rebuild, discard-endpoint purge.
* Registry / loader: decorator registration, duplicate-name rejection, file-path loading, empty-chain no-op.
* Pipeline integration: hooks fire on the correct tool boundaries, metadata lands in finalized trajectories, required failures return HTTP 502, missing sandbox id skips dispatch with a warning, full no-op without a configured chain.
* Plumbing: rollout proxy forwards / omits the sandbox-id header, register payload carries the sandbox id, binding fingerprint distinguishes sandbox ids.
* The example hooks in examples/tool_call_hooks_example.py double as usage documentation, e.g. dressage-proxy --tool-call-hooks examples/tool_call_hooks_example.py:e2b_snapshot.