### PR TITLE
perf(tq): store routed-experts as numpy

### DIFF
--- a/dressage/proxy/routed_experts.py
+++ b/dressage/proxy/routed_experts.py
@@ -70,11 +70,17 @@ def canonicalize_routed_experts(
                 raise ValueError(
                     f"routed-expert id does not fit in {expert_id_dtype}"
                 )
-            selected = selected_values.astype(storage_dtype).tobytes()
+            stored = selected_values.astype(storage_dtype)
+        else:
+            stored = selected_values
         selected_rows = overlap_end - overlap_start
         result.append(
             {
-                "data": _base64.b64encode(selected).decode("ascii"),
+                # Store routed-expert ids as a numpy array (not base64 ASCII).
+                # TransferQueue's msgpack codec serializes ndarrays zero-copy
+                # (CUSTOM_TYPE_NUMPY), dropping the +33% base64 inflation that
+                # dominated the StorageUnit footprint (R3 ids ~92% of payload).
+                "data": np.ascontiguousarray(stored),
                 "row_count": selected_rows,
                 "dtype": expert_id_dtype,
             }

--- a/dressage/proxy/trajectory_store.py
+++ b/dressage/proxy/trajectory_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import copy
 import threading
 import time
@@ -9,10 +10,34 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+import numpy as np
+
 from dressage.transport import (
     TQFieldLayout,
     is_tq_field_layout_dict,
 )
+
+
+def _jsonable_routed_experts_chunks(chunks: Any) -> Any:
+    """Encode ndarray chunk payloads as base64 for JSON transport.
+
+    ``canonicalize_routed_experts`` stores expert ids as numpy arrays so
+    TransferQueue's msgpack codec can serialize them zero-copy. The local
+    (non-offloaded) path still crosses a JSON boundary at
+    ``/trajectory/read``, where ndarrays must use the base64 wire format.
+    """
+
+    if not isinstance(chunks, list):
+        return chunks
+    encoded: list[Any] = []
+    for chunk in chunks:
+        if isinstance(chunk, dict) and isinstance(chunk.get("data"), np.ndarray):
+            chunk = {
+                **chunk,
+                "data": base64.b64encode(chunk["data"].tobytes()).decode("ascii"),
+            }
+        encoded.append(chunk)
+    return encoded
 
 
 @dataclass
@@ -72,7 +97,7 @@ class TrajectorySegment:
             data["routed_experts_chunks"] = (
                 self.routed_experts_chunks.to_dict()
                 if isinstance(self.routed_experts_chunks, TQFieldLayout)
-                else self.routed_experts_chunks
+                else _jsonable_routed_experts_chunks(self.routed_experts_chunks)
             )
         return data
 

--- a/dressage/training/tq_hydration.py
+++ b/dressage/training/tq_hydration.py
@@ -174,21 +174,15 @@ def _materialize_logprobs(
 
 
 def _decode_routed_experts_chunks(value: Any, width: int) -> torch.Tensor:
-    try:
-        import pybase64
-    except ImportError:
-        import base64 as pybase64
-
     arrays = []
     for chunk in value or []:
         row_count = int(chunk["row_count"])
         dtype_name = str(chunk.get("dtype", "int32"))
         if dtype_name not in {"uint8", "uint16", "int32"}:
             raise ValueError(f"unsupported routed experts dtype: {dtype_name}")
-        decoded = np.frombuffer(
-            pybase64.b64decode(str(chunk["data"]).encode("ascii")),
-            dtype=np.dtype(dtype_name),
-        ).astype(np.int32, copy=False)
+        # chunk["data"] is a numpy array stored zero-copy by TransferQueue
+        # (previously a base64 string); reinterpret to int32 for replay.
+        decoded = np.asarray(chunk["data"]).astype(np.int32, copy=False)
         if decoded.size != row_count * width:
             raise ValueError("TransferQueue routed experts chunk shape does not match")
         arrays.append(decoded.reshape(row_count, width).copy())

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -14,6 +14,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 import httpx
 from jinja2 import Environment, StrictUndefined
+import numpy as np
 import pytest
 
 from dressage.proxy import StepRecord, TrajectoryItem, TrajectorySegment, TurnRecord
@@ -636,12 +637,17 @@ def encode_routed_experts(values: list[int]) -> str:
 def decode_routed_expert_chunks(chunks: list[dict]) -> list[int]:
     values: list[int] = []
     for chunk in chunks:
-        typecode = {"uint8": "B", "uint16": "H", "int32": "i"}[
-            chunk.get("dtype", "int32")
-        ]
-        decoded = array(typecode)
-        decoded.frombytes(base64.b64decode(chunk["data"]))
-        values.extend(decoded)
+        payload = chunk["data"]
+        if isinstance(payload, np.ndarray):
+            decoded = payload
+        else:
+            decoded = np.frombuffer(
+                base64.b64decode(payload),
+                dtype=np.dtype(chunk.get("dtype", "int32")),
+            )
+        if decoded.dtype != np.dtype(chunk.get("dtype", "int32")):
+            raise AssertionError("stored dtype does not match the chunk dtype")
+        values.extend(decoded.tolist())
     return values
 
 

--- a/tests/test_routed_experts.py
+++ b/tests/test_routed_experts.py
@@ -18,10 +18,9 @@ def _encode(values: list[int]) -> str:
 def _decode(chunks: list[dict]) -> list[int]:
     values: list[int] = []
     for chunk in chunks:
-        decoded = np.frombuffer(
-            base64.b64decode(chunk["data"]),
-            dtype=np.dtype(chunk.get("dtype", "int32")),
-        )
+        decoded = np.asarray(chunk["data"])
+        if decoded.dtype != np.dtype(chunk.get("dtype", "int32")):
+            raise AssertionError("stored dtype does not match the chunk dtype")
         values.extend(decoded.tolist())
     return values
 
@@ -114,7 +113,8 @@ def test_canonicalize_routed_experts_converts_expert_id_dtype(
     )
 
     assert chunks[0]["dtype"] == expert_id_dtype
-    assert len(base64.b64decode(chunks[0]["data"])) == expected_bytes
+    assert isinstance(chunks[0]["data"], np.ndarray)
+    assert chunks[0]["data"].nbytes == expected_bytes
     assert _decode(chunks) == [1, 2, 3, 4, 5, 6]
 
 

--- a/tests/test_tq_training_hydration.py
+++ b/tests/test_tq_training_hydration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 from types import SimpleNamespace
 
 import numpy as np
@@ -91,9 +90,7 @@ def _routed_experts_chunks(
 ) -> list[dict]:
     return [
         {
-            "data": base64.b64encode(
-                values.astype(dtype, copy=False).tobytes()
-            ).decode("ascii"),
+            "data": np.ascontiguousarray(values.astype(dtype, copy=False)),
             "row_count": values.shape[0],
             "dtype": dtype,
         }


### PR DESCRIPTION
## Summary
Store routed-experts (R3 Expert ID) chunks as native numpy arrays instead of base64 ASCII strings on the TransferQueue path. TransferQueue's msgpack codec serializes ndarrays zero-copy (CUSTOM_TYPE_NUMPY), which eliminates the +33% base64 inflation on the field that dominates the StorageUnit payload (~92%). The local (non-offloaded) path gets a lazy base64 re-encode at its JSON boundary, and the training-side hydration is simplified accordingly.

## Motivation
R3 records the top-k Expert IDs of every MoE layer for every token, making it by far the largest trajectory field (~92.4% of per-segment field storage in our measurements).
Previously, canonicalize_routed_experts encoded the selected rows as dtype.tobytes() + base64 ASCII before handing them to TQ. Base64 inflates the binary payload by 4/3 (+33%), and this inflation was paid in full on every StorageUnit write and subsequent read.
TransferQueue's msgpack codec natively supports zero-copy ndarray serialization, so the base64 layer was pure overhead on the TQ path with no benefit.

## Changes
[canonicalize_routed_experts]: the chunk's data field is now np.ascontiguousarray(stored) instead of a base64 string. Dtype narrowing (uint8/uint16) and range validation are unchanged; only the final packaging differs.
[_jsonable_routed_experts_chunks] new helper that lazily re-encodes ndarray chunks to base64 inside TrajectorySegment.to_dict(). The local path's /trajectory/read still crosses a JSON boundary where ndarrays are not representable, so the original wire format is preserved at that exit point — existing consumers (tests, read paths) are unaffected.
[_decode_routed_experts_chunks]: data read back from TQ is already an ndarray, so the pybase64 import and base64 decode branch are removed; it now does a direct np.asarray(...).astype(np.int32, copy=False) reinterpret before reshape. Shape/row_count validation is unchanged.
Tests updated in lockstep: [test_routed_experts.py]asserts data is an ndarray with matching nbytes; [test_tq_training_hydration.py]fixtures build ndarray chunks directly; [test_proxy.py]'s decode helper accepts both ndarray (in-memory view) and base64 (JSON round-trip) forms and validates dtype consistency.

## Results
Theoretical gain: R3 chunk storage and transfer volume shrink by 25% relative to the base64 format (4/3 → 1). With R3 at ~92% of payload, that translates to roughly a 23% reduction in overall StorageUnit footprint, plus the removed CPU cost of tobytes() + b64encode on write and b64decode on read. No end-to-end benchmark was run; figures are analytical estimates.

## Compatibility
Old TQ data is not compatible: _decode_routed_experts_chunks now assumes chunk["data"] is an ndarray and no longer accepts base64 strings. Stale old-format data in the StorageUnit (cross-version upgrade with retention still live) would fail hydration. Risk is bounded: TQ retention defaults to 86400s, the data is intermediate state within a training run, and it naturally expires within a normal upgrade window.
Local JSON wire format unchanged: /trajectory/read still emits base64, so external consumers see no difference.
np.frombuffer read-only view: the int32 pass-through branch in canonicalize (stored = selected_values) references a read-only buffer from frombuffer; np.ascontiguousarray is a no-op for already-contiguous arrays (no forced copy), and there are no in-place writes downstream — safe.
Dtype semantics unchanged: the training side still recovers a unified int32 tensor; R3 replay algorithm semantics are unaffected.

<img width="1290" height="394" alt="image" src="https://github.com/user-attachments/assets/0a64d965-5afa-41ab-83f6-981ac8970509" />
